### PR TITLE
Fix function's arg default List

### DIFF
--- a/sdgx/models/single_table/ctgan.py
+++ b/sdgx/models/single_table/ctgan.py
@@ -43,7 +43,9 @@ class GeneratorCTGAN(BaseGeneratorModel):
         self.model_type = "CTGAN"
         self.status = "ready"
 
-    def fit(self, input_df, discrete_cols=[]):
+    def fit(self, input_df, discrete_cols=None):
+        if not discrete_cols:
+            discrete_cols = []
         # 模型训练
         self.model.fit(input_df, discrete_cols)
         return


### PR DESCRIPTION
Mutable object such as `Dict` and `List` should never be default value

> Default values are computed once, then re-used.
>
> Default parameter values are evaluated when the function definition is executed. This means that the expression is evaluated once, when the function is defined, and that the same “pre-computed” value is used for each call.

```python
>>> def demo_list(l=[]):
...   l.append("data")
...   return l
...
>>> print(demo_list())
['data']
>>> print(demo_list())
['data', 'data']
```

This can lead to unexpected issues.
