### PR TITLE
Introduce inspect_level in inspector and metadata

### DIFF
--- a/sdgx/data_models/inspectors/base.py
+++ b/sdgx/data_models/inspectors/base.py
@@ -27,6 +27,11 @@ class Inspector:
     We will preset different inspector levels for different inspectors, usually more specific inspectors will get higher levels, and general inspectors (like discrete) will have inspect_level. In baseclass, the inspect_level is set to 1.
     """
 
+    pii = False
+    '''
+    PII refers if a column contains private or sensitive information.m
+    '''
+
     def __init__(self, *args, **kwargs):
         self.ready: bool = False
 

--- a/sdgx/data_models/inspectors/base.py
+++ b/sdgx/data_models/inspectors/base.py
@@ -20,12 +20,12 @@ class Inspector:
         ready (bool): Ready to inspect, maybe all fields are fitted, or indicate if there is more data, inspector will be more precise.
     """
 
-    inspect_level: int = 1 
-    '''
+    inspect_level: int = 1
+    """
     Inspected level is a concept newly introduced in version 0.1.5. Since a single column in the table may be marked by different inspectors at the same time (for example: the email column may be recognized as email, but it may also be recognized as the id column, and it may also be recognized by different inspectors at the same time identified as a discrete column, which will cause confusion in subsequent processing), the inspect_leve is used when determining the specific type of a column.
 
     We will preset different inspector levels for different inspectors, usually more specific inspectors will get higher levels, and general inspectors (like discrete) will have inspect_level. In baseclass, the inspect_level is set to 1.
-    '''
+    """
 
     def __init__(self, *args, **kwargs):
         self.ready: bool = False

--- a/sdgx/data_models/inspectors/base.py
+++ b/sdgx/data_models/inspectors/base.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:
     from sdgx.data_models.metadata import Metadata
 
 from sdgx.data_models.relationship import Relationship
+from sdgx.exceptions import DataModelError
 
 
 class Inspector:
@@ -20,20 +21,36 @@ class Inspector:
         ready (bool): Ready to inspect, maybe all fields are fitted, or indicate if there is more data, inspector will be more precise.
     """
 
-    inspect_level: int = 1
-    """
-    Inspected level is a concept newly introduced in version 0.1.5. Since a single column in the table may be marked by different inspectors at the same time (for example: the email column may be recognized as email, but it may also be recognized as the id column, and it may also be recognized by different inspectors at the same time identified as a discrete column, which will cause confusion in subsequent processing), the inspect_leve is used when determining the specific type of a column.
-
-    We will preset different inspector levels for different inspectors, usually more specific inspectors will get higher levels, and general inspectors (like discrete) will have inspect_level. In baseclass, the inspect_level is set to 1.
-    """
-
     pii = False
     """
     PII refers if a column contains private or sensitive information.m
     """
 
+    _inspect_level: int = 10
+    """
+    Inspected level is a concept newly introduced in version 0.1.5. Since a single column in the table may be marked by different inspectors at the same time (for example: the email column may be recognized as email, but it may also be recognized as the id column, and it may also be recognized by different inspectors at the same time identified as a discrete column, which will cause confusion in subsequent processing), the inspect_leve is used when determining the specific type of a column.
+
+    We will preset different inspector levels for different inspectors, usually more specific inspectors will get higher levels, and general inspectors (like discrete) will have inspect_level. 
+
+    The value of the variable inspect_level is limited to 1-100. In baseclass and bool, discrete and numeric types, the inspect_level is set to 10. For datetime and id types, the inspect_level is set to 20. When a variable is marked multiple times At this time, the mark of the inspector with a higher inspect_level shall prevail. Such a markup method will also make it easier for developers to insert a custom inspector from the middle.
+    """
+
+    @property
+    def inspect_level(self):
+        return self._inspect_level
+
+    @inspect_level.setter
+    def inspect_level(self, value: int):
+        if value > 0 and value <= 100:
+            self._inspect_level = value
+        else:
+            raise DataModelError("The inspect_level should be set in [1, 100].")
+
     def __init__(self, *args, **kwargs):
         self.ready: bool = False
+        # add inspect_level check 
+        if self.inspect_level <= 0 or self.inspect_level > 100:
+            raise DataModelError("The inspect_level should be set in [1, 100].")
 
     def fit(self, raw_data: pd.DataFrame, *args, **kwargs):
         """Fit the inspector.

--- a/sdgx/data_models/inspectors/base.py
+++ b/sdgx/data_models/inspectors/base.py
@@ -30,7 +30,7 @@ class Inspector:
     """
     Inspected level is a concept newly introduced in version 0.1.5. Since a single column in the table may be marked by different inspectors at the same time (for example: the email column may be recognized as email, but it may also be recognized as the id column, and it may also be recognized by different inspectors at the same time identified as a discrete column, which will cause confusion in subsequent processing), the inspect_leve is used when determining the specific type of a column.
 
-    We will preset different inspector levels for different inspectors, usually more specific inspectors will get higher levels, and general inspectors (like discrete) will have inspect_level. 
+    We will preset different inspector levels for different inspectors, usually more specific inspectors will get higher levels, and general inspectors (like discrete) will have inspect_level.
 
     The value of the variable inspect_level is limited to 1-100. In baseclass and bool, discrete and numeric types, the inspect_level is set to 10. For datetime and id types, the inspect_level is set to 20. When a variable is marked multiple times At this time, the mark of the inspector with a higher inspect_level shall prevail. Such a markup method will also make it easier for developers to insert a custom inspector from the middle.
     """
@@ -48,7 +48,7 @@ class Inspector:
 
     def __init__(self, *args, **kwargs):
         self.ready: bool = False
-        # add inspect_level check 
+        # add inspect_level check
         if self.inspect_level <= 0 or self.inspect_level > 100:
             raise DataModelError("The inspect_level should be set in [1, 100].")
 

--- a/sdgx/data_models/inspectors/base.py
+++ b/sdgx/data_models/inspectors/base.py
@@ -28,9 +28,9 @@ class Inspector:
     """
 
     pii = False
-    '''
+    """
     PII refers if a column contains private or sensitive information.m
-    '''
+    """
 
     def __init__(self, *args, **kwargs):
         self.ready: bool = False

--- a/sdgx/data_models/inspectors/base.py
+++ b/sdgx/data_models/inspectors/base.py
@@ -46,11 +46,11 @@ class Inspector:
         else:
             raise DataModelError("The inspect_level should be set in [1, 100].")
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, inspect_level = None, *args, **kwargs):
         self.ready: bool = False
         # add inspect_level check
-        if self.inspect_level <= 0 or self.inspect_level > 100:
-            raise DataModelError("The inspect_level should be set in [1, 100].")
+        if inspect_level:
+            self.inspect_level = inspect_level
 
     def fit(self, raw_data: pd.DataFrame, *args, **kwargs):
         """Fit the inspector.

--- a/sdgx/data_models/inspectors/base.py
+++ b/sdgx/data_models/inspectors/base.py
@@ -46,7 +46,7 @@ class Inspector:
         else:
             raise DataModelError("The inspect_level should be set in [1, 100].")
 
-    def __init__(self, inspect_level = None, *args, **kwargs):
+    def __init__(self, inspect_level=None, *args, **kwargs):
         self.ready: bool = False
         # add inspect_level check
         if inspect_level:

--- a/sdgx/data_models/inspectors/base.py
+++ b/sdgx/data_models/inspectors/base.py
@@ -20,6 +20,13 @@ class Inspector:
         ready (bool): Ready to inspect, maybe all fields are fitted, or indicate if there is more data, inspector will be more precise.
     """
 
+    inspect_level: int = 1 
+    '''
+    Inspected level is a concept newly introduced in version 0.1.5. Since a single column in the table may be marked by different inspectors at the same time (for example: the email column may be recognized as email, but it may also be recognized as the id column, and it may also be recognized by different inspectors at the same time identified as a discrete column, which will cause confusion in subsequent processing), the inspect_leve is used when determining the specific type of a column.
+
+    We will preset different inspector levels for different inspectors, usually more specific inspectors will get higher levels, and general inspectors (like discrete) will have inspect_level. In baseclass, the inspect_level is set to 1.
+    '''
+
     def __init__(self, *args, **kwargs):
         self.ready: bool = False
 

--- a/sdgx/data_models/inspectors/datetime.py
+++ b/sdgx/data_models/inspectors/datetime.py
@@ -11,7 +11,7 @@ from sdgx.utils import ignore_warnings
 
 
 class DatetimeInspector(Inspector):
-    inspect_level = 2
+    _inspect_level = 20
     """
     The inspect_level of DatetimeInspector is higher than DiscreteInspector.
 

--- a/sdgx/data_models/inspectors/datetime.py
+++ b/sdgx/data_models/inspectors/datetime.py
@@ -11,6 +11,14 @@ from sdgx.utils import ignore_warnings
 
 
 class DatetimeInspector(Inspector):
+
+    inspect_level = 2
+    '''
+    The inspect_level of DatetimeInspector is higher than DiscreteInspector.
+
+    Often, difficult-to-recognize date or datetime objects are also recognized as descrete types by DatetimeInspector, causing the column to be marked repeatedly.
+    '''
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.datetime_columns: set[str] = set()

--- a/sdgx/data_models/inspectors/datetime.py
+++ b/sdgx/data_models/inspectors/datetime.py
@@ -11,13 +11,12 @@ from sdgx.utils import ignore_warnings
 
 
 class DatetimeInspector(Inspector):
-
     inspect_level = 2
-    '''
+    """
     The inspect_level of DatetimeInspector is higher than DiscreteInspector.
 
     Often, difficult-to-recognize date or datetime objects are also recognized as descrete types by DatetimeInspector, causing the column to be marked repeatedly.
-    '''
+    """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/sdgx/data_models/inspectors/i_id.py
+++ b/sdgx/data_models/inspectors/i_id.py
@@ -9,7 +9,7 @@ from sdgx.data_models.inspectors.extension import hookimpl
 
 
 class IDInspector(Inspector):
-    inspect_level = 2
+    _inspect_level = 20
     """
     The inspect_level of IDInspector is higher than NumericInspector.
 

--- a/sdgx/data_models/inspectors/i_id.py
+++ b/sdgx/data_models/inspectors/i_id.py
@@ -9,13 +9,12 @@ from sdgx.data_models.inspectors.extension import hookimpl
 
 
 class IDInspector(Inspector):
-
     inspect_level = 2
-    '''
+    """
     The inspect_level of IDInspector is higher than NumericInspector.
 
     Often, some column, especially int type id column can also be recognized as numeric types by NumericInspector, causing the column to be marked repeatedly.
-    '''
+    """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/sdgx/data_models/inspectors/i_id.py
+++ b/sdgx/data_models/inspectors/i_id.py
@@ -9,6 +9,14 @@ from sdgx.data_models.inspectors.extension import hookimpl
 
 
 class IDInspector(Inspector):
+
+    inspect_level = 2
+    '''
+    The inspect_level of IDInspector is higher than NumericInspector.
+
+    Often, some column, especially int type id column can also be recognized as numeric types by NumericInspector, causing the column to be marked repeatedly.
+    '''
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.ID_columns: set[str] = set()

--- a/sdgx/data_models/metadata.py
+++ b/sdgx/data_models/metadata.py
@@ -45,14 +45,14 @@ class Metadata(BaseModel):
     """
 
     column_inspect_level: Dict[str, int] = defaultdict()
-    '''
+    """
     column_inspect_level is used to store every inspector's level, to specify the true type of each column.
-    '''
+    """
 
     pii_columns: Set[set] = set()
-    '''
+    """
     pii_columns is used to store all PII columns' name
-    '''
+    """
 
     # other columns lists are used to store column information
     # here are 5 basic data types
@@ -271,10 +271,10 @@ class Metadata(BaseModel):
             if inspector.pii:
                 for each_key in inspect_res:
                     metadata.update({"pii_columns": inspect_res[each_key]})
-            # update inspect level 
+            # update inspect level
             for each_key in inspect_res:
                 metadata.column_inspect_level[each_key] = inspector.inspect_level
-            
+
         if not primary_keys:
             metadata.update_primary_key(metadata.id_columns)
 
@@ -323,10 +323,10 @@ class Metadata(BaseModel):
             if inspector.pii:
                 for each_key in inspect_res:
                     metadata.update({"pii_columns": inspect_res[each_key]})
-            # update inspect level 
+            # update inspect level
             for each_key in inspect_res:
                 metadata.column_inspect_level[each_key] = inspector.inspect_level
-        
+
         if check:
             metadata.check()
         return metadata

--- a/sdgx/data_models/metadata.py
+++ b/sdgx/data_models/metadata.py
@@ -446,36 +446,41 @@ class Metadata(BaseModel):
 
     def get_summary(self):
         # still draft
-        
+
         pass
-    
+
     def get_column_data_type(self, column_name: str):
-        ''' Get the exact type of specific column.
+        """Get the exact type of specific column.
         Args:
             column_name(str): The query colmun name.
         Returns:
             str: The data type query result.
-        '''
+        """
         if column_name not in self.column_list:
             raise MetadataInvalidError(f"Column {column_name}not exists in metadata.")
         current_type = None
         current_level = 0
-        # find the dtype who has most high inspector level 
+        # find the dtype who has most high inspector level
         for each_key in list(self.model_fields.keys()) + list(self._extend.keys()):
-            if each_key != "pii_columns" and each_key.endswith("_columns") and column_name in self.get(each_key) and current_level < self.column_inspect_level[each_key]:
+            if (
+                each_key != "pii_columns"
+                and each_key.endswith("_columns")
+                and column_name in self.get(each_key)
+                and current_level < self.column_inspect_level[each_key]
+            ):
                 current_level = self.column_inspect_level[each_key]
-                current_type  = each_key
+                current_type = each_key
         if not current_type:
             raise MetadataInvalidError(f"Column {column_name} has no data type.")
-        return current_type.split('_columns')[0]
-    
-    def get_column_pii(self, column_name:str):
-        ''' Return if a column is a PII column.
+        return current_type.split("_columns")[0]
+
+    def get_column_pii(self, column_name: str):
+        """Return if a column is a PII column.
         Args:
             column_name(str): The query colmun name.
         Returns:
             bool: The PII query result.
-        '''
+        """
         if column_name not in self.column_list:
             raise MetadataInvalidError(f"Column {column_name}not exists in metadata.")
         if column_name in self.pii_columns:

--- a/sdgx/data_models/metadata.py
+++ b/sdgx/data_models/metadata.py
@@ -341,8 +341,9 @@ class Metadata(BaseModel):
 
         if input_key not in self.column_list:
             raise MetadataInvalidError(f"Primary Key {input_key} not Exist in columns.")
-        if input_key not in self.id_columns:
-            raise MetadataInvalidError(f"Primary Key {input_key} should has ID DataType.")
+        
+
+
 
     def get_all_data_type_columns(self):
         """Get all column names from `self.xxx_columns`.
@@ -371,9 +372,13 @@ class Metadata(BaseModel):
             -Is there any missing definition of each column in table.
             -Are there any unknown columns that have been incorrectly updated.
         """
-        # check primary key in column_list and has ID data type
+        # check primary key in column_list
         for each_key in self.primary_keys:
             self.check_single_primary_key(each_key)
+        
+        # for single primary key, it should has ID type
+        if len(self.primary_keys) == 1 and self.primary_keys[0] not in self.id_columns:
+            raise MetadataInvalidError(f"Primary Key {self.primary_keys[0]} should has ID DataType.")
 
         all_dtype_columns = self.get_all_data_type_columns()
 

--- a/sdgx/data_models/metadata.py
+++ b/sdgx/data_models/metadata.py
@@ -446,14 +446,14 @@ class Metadata(BaseModel):
 
     def dump(self):
         """Dump model dict, can be used in downstream process, like processor.
-        
+
         Returns:
             dict: dumped dict.
         """
         model_dict = self.model_dump()
-        model_dict['column_data_type'] = {}
+        model_dict["column_data_type"] = {}
         for each_col in self.column_list:
-            model_dict['column_data_type'][each_col] = self.get_column_data_type(each_col)
+            model_dict["column_data_type"][each_col] = self.get_column_data_type(each_col)
         return model_dict
 
     def get_column_data_type(self, column_name: str):

--- a/sdgx/data_models/metadata.py
+++ b/sdgx/data_models/metadata.py
@@ -444,10 +444,17 @@ class Metadata(BaseModel):
 
         logger.info(f"Primary Key updated: {primary_keys}.")
 
-    def get_summary(self):
-        # still draft
-
-        pass
+    def dump(self):
+        """Dump model dict, can be used in downstream process, like processor.
+        
+        Returns:
+            dict: dumped dict.
+        """
+        model_dict = self.model_dump()
+        model_dict['column_data_type'] = {}
+        for each_col in self.column_list:
+            model_dict['column_data_type'][each_col] = self.get_column_data_type(each_col)
+        return model_dict
 
     def get_column_data_type(self, column_name: str):
         """Get the exact type of specific column.

--- a/sdgx/data_models/metadata.py
+++ b/sdgx/data_models/metadata.py
@@ -341,9 +341,6 @@ class Metadata(BaseModel):
 
         if input_key not in self.column_list:
             raise MetadataInvalidError(f"Primary Key {input_key} not Exist in columns.")
-        
-
-
 
     def get_all_data_type_columns(self):
         """Get all column names from `self.xxx_columns`.
@@ -375,10 +372,12 @@ class Metadata(BaseModel):
         # check primary key in column_list
         for each_key in self.primary_keys:
             self.check_single_primary_key(each_key)
-        
+
         # for single primary key, it should has ID type
         if len(self.primary_keys) == 1 and self.primary_keys[0] not in self.id_columns:
-            raise MetadataInvalidError(f"Primary Key {self.primary_keys[0]} should has ID DataType.")
+            raise MetadataInvalidError(
+                f"Primary Key {self.primary_keys[0]} should has ID DataType."
+            )
 
         all_dtype_columns = self.get_all_data_type_columns()
 

--- a/sdgx/data_models/metadata.py
+++ b/sdgx/data_models/metadata.py
@@ -388,7 +388,6 @@ class Metadata(BaseModel):
             if each_key.endswith("_columns"):
                 column_names = self.get(each_key)
                 all_dtype_cols = all_dtype_cols.union(set(column_names))
-
         return all_dtype_cols
 
     def check(self):
@@ -444,3 +443,41 @@ class Metadata(BaseModel):
         self.primary_keys = primary_keys
 
         logger.info(f"Primary Key updated: {primary_keys}.")
+
+    def get_summary(self):
+        # still draft
+        
+        pass
+    
+    def get_column_data_type(self, column_name: str):
+        ''' Get the exact type of specific column.
+        Args:
+            column_name(str): The query colmun name.
+        Returns:
+            str: The data type query result.
+        '''
+        if column_name not in self.column_list:
+            raise MetadataInvalidError(f"Column {column_name}not exists in metadata.")
+        current_type = None
+        current_level = 0
+        # find the dtype who has most high inspector level 
+        for each_key in list(self.model_fields.keys()) + list(self._extend.keys()):
+            if each_key != "pii_columns" and each_key.endswith("_columns") and column_name in self.get(each_key) and current_level < self.column_inspect_level[each_key]:
+                current_level = self.column_inspect_level[each_key]
+                current_type  = each_key
+        if not current_type:
+            raise MetadataInvalidError(f"Column {column_name} has no data type.")
+        return current_type.split('_columns')[0]
+    
+    def get_column_pii(self, column_name:str):
+        ''' Return if a column is a PII column.
+        Args:
+            column_name(str): The query colmun name.
+        Returns:
+            bool: The PII query result.
+        '''
+        if column_name not in self.column_list:
+            raise MetadataInvalidError(f"Column {column_name}not exists in metadata.")
+        if column_name in self.pii_columns:
+            return True
+        return False

--- a/sdgx/data_models/metadata.py
+++ b/sdgx/data_models/metadata.py
@@ -44,7 +44,7 @@ class Metadata(BaseModel):
     column_list is used to store all columns' name
     """
 
-    column_inspect_level: Dict[str, int] = defaultdict()
+    column_inspect_level: Dict[str, int] = defaultdict(lambda: 10)
     """
     column_inspect_level is used to store every inspector's level, to specify the true type of each column.
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,6 +161,15 @@ def demo_multi_table_data_loader(demo_multi_table_data_connector, cacher_kwargs)
     for each_table in demo_multi_table_data_connector.keys():
         demo_multi_table_data_connector[each_table].finalize()
 
+@pytest.fixture
+def demo_multi_data_parent_matadata(demo_multi_table_data_loader):
+    yield Metadata.from_dataloader(
+        demo_multi_table_data_loader['store'])
+    
+@pytest.fixture
+def demo_multi_data_child_matadata(demo_multi_table_data_loader):
+    yield Metadata.from_dataloader(
+        demo_multi_table_data_loader['train'])
 
 @pytest.fixture
 def demo_multi_data_relationship():
@@ -169,13 +178,14 @@ def demo_multi_data_relationship():
 
 @pytest.fixture
 def demo_multi_table_data_metadata_combiner(
-    demo_multi_table_data_loader, demo_multi_data_relationship
-):
+    demo_multi_data_parent_matadata: Metadata,
+    demo_multi_data_child_matadata: Metadata,
+    demo_multi_data_relationship: Relationship
+    ):
     # 1. get metadata
     metadata_dict = {}
-    for each_table_name in demo_multi_table_data_loader:
-        each_metadata = Metadata.from_dataloader(demo_multi_table_data_loader[each_table_name])
-        metadata_dict[each_table_name] = each_metadata
+    metadata_dict['store'] = demo_multi_data_parent_matadata
+    metadata_dict['train'] = demo_multi_data_child_matadata
     # 2. define relationship - already defined
     # 3. define combiner
     m = MetadataCombiner(named_metadata=metadata_dict, relationships=[demo_multi_data_relationship])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,15 +161,16 @@ def demo_multi_table_data_loader(demo_multi_table_data_connector, cacher_kwargs)
     for each_table in demo_multi_table_data_connector.keys():
         demo_multi_table_data_connector[each_table].finalize()
 
+
 @pytest.fixture
 def demo_multi_data_parent_matadata(demo_multi_table_data_loader):
-    yield Metadata.from_dataloader(
-        demo_multi_table_data_loader['store'])
-    
+    yield Metadata.from_dataloader(demo_multi_table_data_loader["store"])
+
+
 @pytest.fixture
 def demo_multi_data_child_matadata(demo_multi_table_data_loader):
-    yield Metadata.from_dataloader(
-        demo_multi_table_data_loader['train'])
+    yield Metadata.from_dataloader(demo_multi_table_data_loader["train"])
+
 
 @pytest.fixture
 def demo_multi_data_relationship():
@@ -180,12 +181,12 @@ def demo_multi_data_relationship():
 def demo_multi_table_data_metadata_combiner(
     demo_multi_data_parent_matadata: Metadata,
     demo_multi_data_child_matadata: Metadata,
-    demo_multi_data_relationship: Relationship
-    ):
+    demo_multi_data_relationship: Relationship,
+):
     # 1. get metadata
     metadata_dict = {}
-    metadata_dict['store'] = demo_multi_data_parent_matadata
-    metadata_dict['train'] = demo_multi_data_child_matadata
+    metadata_dict["store"] = demo_multi_data_parent_matadata
+    metadata_dict["train"] = demo_multi_data_child_matadata
     # 2. define relationship - already defined
     # 3. define combiner
     m = MetadataCombiner(named_metadata=metadata_dict, relationships=[demo_multi_data_relationship])

--- a/tests/data_models/inspector/test_bool.py
+++ b/tests/data_models/inspector/test_bool.py
@@ -39,7 +39,7 @@ def test_inspector_demo_data(inspector: BoolInspector, raw_data):
     assert not inspector.bool_columns
     assert sorted(inspector.inspect()["bool_columns"]) == sorted([])
     assert inspector.inspect_level == 10
-    # test inspect_level.setter 
+    # test inspect_level.setter
     try:
         inspector.inspect_level = 120
     except Exception as e:

--- a/tests/data_models/inspector/test_bool.py
+++ b/tests/data_models/inspector/test_bool.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pytest
 
 from sdgx.data_models.inspectors.bool import BoolInspector
+from sdgx.exceptions import DataModelError
 
 
 @pytest.fixture
@@ -37,6 +38,12 @@ def test_inspector_demo_data(inspector: BoolInspector, raw_data):
     # should be empty set
     assert not inspector.bool_columns
     assert sorted(inspector.inspect()["bool_columns"]) == sorted([])
+    assert inspector.inspect_level == 10
+    # test inspect_level.setter 
+    try:
+        inspector.inspect_level = 120
+    except Exception as e:
+        assert type(e) == DataModelError
 
 
 def test_inspector_generated_data(inspector: BoolInspector, bool_test_df: pd.DataFrame):
@@ -44,6 +51,11 @@ def test_inspector_generated_data(inspector: BoolInspector, bool_test_df: pd.Dat
     inspector.fit(bool_test_df)
     assert inspector.bool_columns
     assert sorted(inspector.inspect()["bool_columns"]) == sorted(["bool_random"])
+    assert inspector.inspect_level == 10
+    try:
+        inspector.inspect_level = 0
+    except Exception as e:
+        assert type(e) == DataModelError
 
 
 if __name__ == "__main__":

--- a/tests/data_models/inspector/test_datetime.py
+++ b/tests/data_models/inspector/test_datetime.py
@@ -74,6 +74,7 @@ def test_inspector_demo_data(inspector: DatetimeInspector, raw_data):
     # should be empty set
     assert not inspector.datetime_columns
     assert sorted(inspector.inspect()["datetime_columns"]) == sorted([])
+    assert inspector.inspect_level == 20
 
 
 def test_inspector_generated_data(inspector: DatetimeInspector, datetime_test_df: pd.DataFrame):
@@ -83,6 +84,7 @@ def test_inspector_generated_data(inspector: DatetimeInspector, datetime_test_df
     assert sorted(inspector.inspect()["datetime_columns"]) == sorted(
         ["simple_datetime", "simple_datetime_2", "date_with_time"]
     )
+    assert inspector.inspect_level == 20
 
 
 if __name__ == "__main__":

--- a/tests/data_models/inspector/test_discrete.py
+++ b/tests/data_models/inspector/test_discrete.py
@@ -31,6 +31,7 @@ def test_inspector(inspector: DiscreteInspector, raw_data):
             "class",
         ]
     )
+    assert inspector.inspect_level == 10
 
 
 if __name__ == "__main__":

--- a/tests/data_models/inspector/test_i_id.py
+++ b/tests/data_models/inspector/test_i_id.py
@@ -38,6 +38,7 @@ def test_inspector_demo_data(inspector: IDInspector, raw_data):
     # should be empty set
     assert not inspector.ID_columns
     assert sorted(inspector.inspect()["id_columns"]) == sorted([])
+    assert inspector.inspect_level == 20
 
 
 def test_inspector_generated_data(inspector: IDInspector, id_test_df: pd.DataFrame):

--- a/tests/data_models/inspector/test_numeric.py
+++ b/tests/data_models/inspector/test_numeric.py
@@ -21,6 +21,7 @@ def test_inspector(inspector: NumericInspector, raw_data):
     assert sorted(inspector.inspect()["numeric_columns"]) == sorted(
         ["education-num", "fnlwgt", "hoursperweek", "age", "capitalgain", "capitalloss"]
     )
+    assert inspector.inspect_level == 10
 
 
 if __name__ == "__main__":

--- a/tests/data_models/test_metadata.py
+++ b/tests/data_models/test_metadata.py
@@ -59,5 +59,47 @@ def test_metadata_check(metadata: Metadata):
     metadata.check()
 
 
+def test_demo_multi_table_data_metadata_parent(demo_multi_data_parent_matadata):
+    # self check
+    demo_multi_data_parent_matadata.check()
+    # check each col's data type 
+    assert demo_multi_data_parent_matadata.get_column_data_type('Store') == 'id'
+    assert demo_multi_data_parent_matadata.get_column_data_type('StoreType') == 'discrete'
+    assert demo_multi_data_parent_matadata.get_column_data_type('Assortment') == 'discrete'
+    assert demo_multi_data_parent_matadata.get_column_data_type('CompetitionDistance') == 'numeric'
+    assert demo_multi_data_parent_matadata.get_column_data_type('CompetitionOpenSinceMonth') == 'numeric'
+    assert demo_multi_data_parent_matadata.get_column_data_type('Promo2') == 'numeric'
+    assert demo_multi_data_parent_matadata.get_column_data_type('Promo2SinceWeek') == 'numeric'
+    assert demo_multi_data_parent_matadata.get_column_data_type('Promo2SinceYear') == 'numeric'
+    assert demo_multi_data_parent_matadata.get_column_data_type('PromoInterval') == 'discrete'
+    # check pii 
+    for each_col in demo_multi_data_parent_matadata.column_list:
+        assert demo_multi_data_parent_matadata.get_column_pii(each_col) is False
+    assert len(demo_multi_data_parent_matadata.pii_columns) is 0
+    # check dump 
+    assert 'column_data_type' in demo_multi_data_parent_matadata.dump().keys()
+
+
+def test_demo_multi_table_data_metadata_child(demo_multi_data_child_matadata):
+    # self check 
+    demo_multi_data_child_matadata.check()
+    # check each col's data type 
+    assert demo_multi_data_child_matadata.get_column_data_type('Store') == 'numeric'
+    assert demo_multi_data_child_matadata.get_column_data_type('Date') == 'datetime'
+    assert demo_multi_data_child_matadata.get_column_data_type('Customers') == 'numeric'
+    assert demo_multi_data_child_matadata.get_column_data_type('StateHoliday') == 'numeric'
+    assert demo_multi_data_child_matadata.get_column_data_type('Sales') == 'numeric'
+    assert demo_multi_data_child_matadata.get_column_data_type('Promo') == 'numeric'
+    assert demo_multi_data_child_matadata.get_column_data_type('DayOfWeek') == 'numeric'
+    assert demo_multi_data_child_matadata.get_column_data_type('Open') == 'numeric'
+    assert demo_multi_data_child_matadata.get_column_data_type('SchoolHoliday') == 'numeric'
+    # check pii 
+    for each_col in demo_multi_data_child_matadata.column_list:
+        assert demo_multi_data_child_matadata.get_column_pii(each_col) is False
+    assert len(demo_multi_data_child_matadata.pii_columns) is 0
+    # check dump 
+    assert 'column_data_type' in demo_multi_data_child_matadata.dump().keys()
+    
+
 if __name__ == "__main__":
     pytest.main(["-vv", "-s", __file__])

--- a/tests/data_models/test_metadata.py
+++ b/tests/data_models/test_metadata.py
@@ -62,44 +62,47 @@ def test_metadata_check(metadata: Metadata):
 def test_demo_multi_table_data_metadata_parent(demo_multi_data_parent_matadata):
     # self check
     demo_multi_data_parent_matadata.check()
-    # check each col's data type 
-    assert demo_multi_data_parent_matadata.get_column_data_type('Store') == 'id'
-    assert demo_multi_data_parent_matadata.get_column_data_type('StoreType') == 'discrete'
-    assert demo_multi_data_parent_matadata.get_column_data_type('Assortment') == 'discrete'
-    assert demo_multi_data_parent_matadata.get_column_data_type('CompetitionDistance') == 'numeric'
-    assert demo_multi_data_parent_matadata.get_column_data_type('CompetitionOpenSinceMonth') == 'numeric'
-    assert demo_multi_data_parent_matadata.get_column_data_type('Promo2') == 'numeric'
-    assert demo_multi_data_parent_matadata.get_column_data_type('Promo2SinceWeek') == 'numeric'
-    assert demo_multi_data_parent_matadata.get_column_data_type('Promo2SinceYear') == 'numeric'
-    assert demo_multi_data_parent_matadata.get_column_data_type('PromoInterval') == 'discrete'
-    # check pii 
+    # check each col's data type
+    assert demo_multi_data_parent_matadata.get_column_data_type("Store") == "id"
+    assert demo_multi_data_parent_matadata.get_column_data_type("StoreType") == "discrete"
+    assert demo_multi_data_parent_matadata.get_column_data_type("Assortment") == "discrete"
+    assert demo_multi_data_parent_matadata.get_column_data_type("CompetitionDistance") == "numeric"
+    assert (
+        demo_multi_data_parent_matadata.get_column_data_type("CompetitionOpenSinceMonth")
+        == "numeric"
+    )
+    assert demo_multi_data_parent_matadata.get_column_data_type("Promo2") == "numeric"
+    assert demo_multi_data_parent_matadata.get_column_data_type("Promo2SinceWeek") == "numeric"
+    assert demo_multi_data_parent_matadata.get_column_data_type("Promo2SinceYear") == "numeric"
+    assert demo_multi_data_parent_matadata.get_column_data_type("PromoInterval") == "discrete"
+    # check pii
     for each_col in demo_multi_data_parent_matadata.column_list:
         assert demo_multi_data_parent_matadata.get_column_pii(each_col) is False
     assert len(demo_multi_data_parent_matadata.pii_columns) is 0
-    # check dump 
-    assert 'column_data_type' in demo_multi_data_parent_matadata.dump().keys()
+    # check dump
+    assert "column_data_type" in demo_multi_data_parent_matadata.dump().keys()
 
 
 def test_demo_multi_table_data_metadata_child(demo_multi_data_child_matadata):
-    # self check 
+    # self check
     demo_multi_data_child_matadata.check()
-    # check each col's data type 
-    assert demo_multi_data_child_matadata.get_column_data_type('Store') == 'numeric'
-    assert demo_multi_data_child_matadata.get_column_data_type('Date') == 'datetime'
-    assert demo_multi_data_child_matadata.get_column_data_type('Customers') == 'numeric'
-    assert demo_multi_data_child_matadata.get_column_data_type('StateHoliday') == 'numeric'
-    assert demo_multi_data_child_matadata.get_column_data_type('Sales') == 'numeric'
-    assert demo_multi_data_child_matadata.get_column_data_type('Promo') == 'numeric'
-    assert demo_multi_data_child_matadata.get_column_data_type('DayOfWeek') == 'numeric'
-    assert demo_multi_data_child_matadata.get_column_data_type('Open') == 'numeric'
-    assert demo_multi_data_child_matadata.get_column_data_type('SchoolHoliday') == 'numeric'
-    # check pii 
+    # check each col's data type
+    assert demo_multi_data_child_matadata.get_column_data_type("Store") == "numeric"
+    assert demo_multi_data_child_matadata.get_column_data_type("Date") == "datetime"
+    assert demo_multi_data_child_matadata.get_column_data_type("Customers") == "numeric"
+    assert demo_multi_data_child_matadata.get_column_data_type("StateHoliday") == "numeric"
+    assert demo_multi_data_child_matadata.get_column_data_type("Sales") == "numeric"
+    assert demo_multi_data_child_matadata.get_column_data_type("Promo") == "numeric"
+    assert demo_multi_data_child_matadata.get_column_data_type("DayOfWeek") == "numeric"
+    assert demo_multi_data_child_matadata.get_column_data_type("Open") == "numeric"
+    assert demo_multi_data_child_matadata.get_column_data_type("SchoolHoliday") == "numeric"
+    # check pii
     for each_col in demo_multi_data_child_matadata.column_list:
         assert demo_multi_data_child_matadata.get_column_pii(each_col) is False
     assert len(demo_multi_data_child_matadata.pii_columns) is 0
-    # check dump 
-    assert 'column_data_type' in demo_multi_data_child_matadata.dump().keys()
-    
+    # check dump
+    assert "column_data_type" in demo_multi_data_child_matadata.dump().keys()
+
 
 if __name__ == "__main__":
     pytest.main(["-vv", "-s", __file__])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Inspected level is a concept newly introduced in version 0.1.5. 

Since a single column in the table may be marked by different inspectors at the same time, which may cause confuse.

Thus, a `inspect_level` is introduced when determining the specific type of a column.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

A single column, can be labeled by different multiple inspector.

For example, A email column may be recognized as email, but it may also be recognized as the id column, and it may also be recognized by different inspectors at the same time identified as a discrete column, which will cause confusion in subsequent processing. 

Also, you can see from our multi-table demo dataset, child table "train",  the `Date` column is marked twice, as discrete type and date type.

We will preset different inspector levels for different inspectors, usually more specific inspectors will get higher levels, and general inspectors (like discrete) will have inspect_level. In baseclass, the inspect_level is set to 1.


## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Maintenance (no change in code, maintain the project's CI, docs, etc.)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.