### PR TITLE
Implement datetime_formats in DatetimeInspector

### DIFF
--- a/tests/data_models/inspector/test_datetime.py
+++ b/tests/data_models/inspector/test_datetime.py
@@ -87,5 +87,29 @@ def test_inspector_generated_data(inspector: DatetimeInspector, datetime_test_df
     assert inspector.inspect_level == 20
 
 
+def test_custom_format_detection(datetime_test_df: pd.DataFrame):
+    # Instantiate the DatetimeInspector with the custom formats
+    inspector = DatetimeInspector(user_formats=["%Y-%m-%d %H:%M:%S"])
+    inspector.fit(datetime_test_df)
+
+    # Get the detected datetime formats
+    result = inspector.inspect()
+
+    # Assert that the detected formats are correct
+    assert result["datetime_formats"]["simple_datetime"] == "%Y-%m-%d %H:%M:%S"
+    assert result["datetime_formats"]["simple_datetime_2"] == "%d %b %Y"
+    assert result["datetime_formats"]["date_with_time"] == "%Y-%m-%d %H:%M:%S"
+    assert inspector.inspect_level == 20
+
+
+def test_detect_datetime_format_partial_and_no_match(inspector):
+    partial_match_series = pd.Series(["2023-03-17", "invalid-date"])
+    no_match_series = pd.Series(["not-a-date"])
+
+    assert inspector.detect_datetime_format(partial_match_series) == None
+    assert inspector.detect_datetime_format(no_match_series) == None
+    assert inspector.inspect_level == 20
+
+
 if __name__ == "__main__":
     pytest.main(["-vv", "-s", __file__])


### PR DESCRIPTION
## Description
I have enhanced the `DatetimeInspector` class to include the capability to detect the specific format of datetime data in each identified datetime column. This enhancement involves adding a new method `detect_datetime_format` which iterates over a list of user-defined and preset datetime formats, attempting to parse dates in a series using each format. The `fit` method has been updated to utilize this new functionality, thereby not only identifying datetime columns but also determining their specific formats.

## Motivation and Context
It was requested in #95 

## How has this been tested?
The changes have been thoroughly tested with a series of new unit tests that cover a wide range of scenarios, including:
- Successful format detection for uniform datetime series.
- Detection failure in cases of mixed valid and invalid datetime strings.
- Proper utilization of user-defined formats in format detection.

## Types of changes
- [ ] Maintenance (no change in code, maintain the project's CI, docs, etc.)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
