### PR TITLE
bugfix: SingleTableGPTModel._sample_with_data  "has no attribute 'result'"

### DIFF
--- a/sdgx/models/LLM/single_table/gpt.py
+++ b/sdgx/models/LLM/single_table/gpt.py
@@ -515,4 +515,4 @@ class SingleTableGPTModel(LLMBaseModel):
 
         # return result
         final_columns = self.columns + self.off_table_features
-        return pd.DataFrame(self.result, columns=final_columns)
+        return pd.DataFrame(result, columns=final_columns)


### PR DESCRIPTION
Fixes a typo in SingleTableGPTModel._sample_with_data

## Description
SingleTableGPTModel._sample_with_data: [Line 518](https://github.com/aaronrmm/synthetic-data-generator/blob/61d123b50bf68a9bc3f02665251201181daf4e86/sdgx/models/LLM/single_table/gpt.py#L518) returns `pd.DataFrame(self.result, columns=final_columns)`, but SingleTableGPTModel has no attribute self.result. This should instead be the local variable "result" defined at [line 494](https://github.com/aaronrmm/synthetic-data-generator/blob/61d123b50bf68a9bc3f02665251201181daf4e86/sdgx/models/LLM/single_table/gpt.py#L494). This correction also follows the structure of [SingleTableGPTModel._sample_with_metadata](https://github.com/aaronrmm/synthetic-data-generator/blob/61d123b50bf68a9bc3f02665251201181daf4e86/sdgx/models/LLM/single_table/gpt.py#L436) at [line 478](https://github.com/aaronrmm/synthetic-data-generator/blob/61d123b50bf68a9bc3f02665251201181daf4e86/sdgx/models/LLM/single_table/gpt.py#L478C9-L478C59)

## Motivation and Context
Currently, the workflow of fitting a SingleTableGPTModel with a dataframe and then sampling results fails, whereas fitting with metadata instead before sampling succeeds.

If SingleTableGPTModel.fit(df) is called with df being a DataFrame, then subsequent calls to SingleTableGPTModel.sample fail with the error "AttributeError: 'SingleTableGPTModel' object has no attribute 'result'". 

When SingleTableGPTModel is fit with a full dataframe and not just metadata, the model's use_raw_data flag is set to True, and calls to model.sample call self._sample_with_metadata which has a typo causing this error.



## How has this been tested?
I ran into the error in the sdg_example_LLM_2 colab notebook. After adding my OPEN_AI_KEY and running the full notebook successfully, I added and ran this cell which gave me the error:
```
model = SingleTableGPTModel()
model.set_openAI_settings(OPEN_AI_BASE, OPEN_AI_KEY)
model.gpt_model = "gpt-3.5-turbo"

model.fit(df)
# this may take a while
model.sample(4, off_table_features = ['owns house'])
```
```
2024-04-17 15:45:02.734 | INFO     | sdgx.models.LLM.single_table.gpt:_fit_with_data:247 - Fitting model with raw data...
2024-04-17 15:45:12.819 | INFO     | sdgx.models.LLM.single_table.gpt:_fit_with_data:272 - Fitting model with raw data... Finished.
2024-04-17 15:45:12.825 | INFO     | sdgx.models.LLM.single_table.gpt:sample:388 - Sampling use GPT model ...
2024-04-17 15:45:12.829 | INFO     | sdgx.models.LLM.single_table.gpt:_sample_with_data:493 - Sampling with raw_data.
2024-04-17 15:45:12.831 | INFO     | sdgx.models.LLM.base:_form_dataset_description:122 - No dataset_description given in current model.
2024-04-17 15:45:12.839 | INFO     | sdgx.models.LLM.base:_form_message_with_offtable_features:108 - No off_table_feature needed in current model.
2024-04-17 15:45:12.909 | INFO     | sdgx.models.LLM.single_table.gpt:ask_gpt:166 - Ask GPT with temperature = 0.1.
2024-04-17 15:45:19.826 | INFO     | sdgx.models.LLM.single_table.gpt:ask_gpt:179 - Ask GPT Finished.
2024-04-17 15:45:19.829 | INFO     | sdgx.models.LLM.single_table.gpt:extract_samples_from_response:360 - Extracting samples from response ...
2024-04-17 15:45:19.831 | INFO     | sdgx.models.LLM.single_table.gpt:extract_samples_from_response:372 - Extracting samples from response ... Finished, 4 extracted.

---------------------------------------------------------------------------

AttributeError                            Traceback (most recent call last)

[<ipython-input-7-7a17bdb3b69f>](https://localhost:8080/#) in <cell line: 7>()
      5 model.fit(df)
      6 # this may take a while
----> 7 model.sample(4, off_table_features = ['owns house'])

1 frames

[/usr/local/lib/python3.10/dist-packages/sdgx/models/LLM/single_table/gpt.py](https://localhost:8080/#) in _sample_with_data(self, count, *args, **kwargs)
    516         # return result
    517         final_columns = self.columns + self.off_table_features
--> 518         return pd.DataFrame(self.result, columns=final_columns)

AttributeError: 'SingleTableGPTModel' object has no attribute 'result'
```
I then added and ran this cell to test the corrected method, which gave me results and no error:
```

from sdgx.models.LLM.single_table.gpt import *
def _sample_with_data(self, count, *args, **kwargs):
    """
    This function samples data with a given count and returns a DataFrame with the sampled data.

    Args:
        count (int): The number of data samples to be generated.
        *args: Variable length argument list.
        **kwargs: Arbitrary keyword arguments.

    Returns:
        pd.DataFrame: A DataFrame containing the sampled data.

    """
    logger.info("Sampling with raw_data.")
    result = []
    remaining_cnt = count
    while remaining_cnt > 0:
        # get the current count
        if remaining_cnt - self.query_batch >= 0:
            current_cnt = self.query_batch
        else:
            current_cnt = remaining_cnt
        # select data / form message
        sample_list = self._select_random_elements(self._sample_lines, current_cnt)
        message = self._form_message_with_data(sample_list, current_cnt)
        # ask_gpt
        response = self.ask_gpt(message)
        # get result from response
        generated_batch = self.extract_samples_from_response(response)
        # update result
        result += generated_batch
        # update remaining_cnt
        remaining_cnt = remaining_cnt - current_cnt

    self._result_list.append(result)

    # return result
    final_columns = self.columns + self.off_table_features
    return pd.DataFrame(result, columns=final_columns)

# Replace the erroneous version of the method with the new corrected method
SingleTableGPTModel._sample_with_data = _sample_with_data

# Rerun the call that failed before
model.sample(4, off_table_features = ['owns house'])
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Maintenance (no change in code, maintain the project's CI, docs, etc.)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.