### PR TITLE
Fix precision problem in metric's testcases

### DIFF
--- a/tests/metrics/test_MISim.py
+++ b/tests/metrics/test_MISim.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import math
 import random
 from datetime import datetime, timedelta
 
@@ -94,8 +93,8 @@ def test_MISim_continuous(test_data_num, mi_sim_instance):
 
     assert result >= 0
     assert result <= 1
-    assert result1 == 1
-    assert round(result2, 9) == round(result, 9)
+    assert np.isclose(result1, 0, atol = 1e-9)
+    assert np.isclose(result, result2, atol = 1e-9)
 
 
 def test_MISim_time(test_data_time, mi_sim_instance):
@@ -108,8 +107,8 @@ def test_MISim_time(test_data_time, mi_sim_instance):
 
     assert result >= 0
     assert result <= 1
-    assert result1 == 1
-    assert result2 == result
+    assert np.isclose(result1, 1, atol=1e-9)
+    assert np.isclose(result, result2, atol=1e-9)
 
 
 if __name__ == "__main__":

--- a/tests/metrics/test_MISim.py
+++ b/tests/metrics/test_MISim.py
@@ -93,8 +93,8 @@ def test_MISim_continuous(test_data_num, mi_sim_instance):
 
     assert result >= 0
     assert result <= 1
-    assert np.isclose(result1, 1, atol = 1e-9)
-    assert np.isclose(result, result2, atol = 1e-9)
+    assert np.isclose(result1, 1, atol=1e-9)
+    assert np.isclose(result, result2, atol=1e-9)
 
 
 def test_MISim_time(test_data_time, mi_sim_instance):

--- a/tests/metrics/test_MISim.py
+++ b/tests/metrics/test_MISim.py
@@ -93,7 +93,7 @@ def test_MISim_continuous(test_data_num, mi_sim_instance):
 
     assert result >= 0
     assert result <= 1
-    assert np.isclose(result1, 0, atol = 1e-9)
+    assert np.isclose(result1, 1, atol = 1e-9)
     assert np.isclose(result, result2, atol = 1e-9)
 
 

--- a/tests/metrics/test_jsd.py
+++ b/tests/metrics/test_jsd.py
@@ -40,9 +40,8 @@ def test_jsd_discrete(dummy_data, test_data, jsd_instance):
 
     assert result >= 0
     assert result <= 1
-    assert result1 == 0
-    assert result2 == result
-
+    assert np.isclose(result1, 0, atol = 1e-9)
+    assert np.isclose(result, result2, atol = 1e-9)
 
 def test_jsd_continuous(dummy_data, test_data, jsd_instance):
     cols = ["feature_x"]
@@ -51,7 +50,7 @@ def test_jsd_continuous(dummy_data, test_data, jsd_instance):
 
     assert result >= 0
     assert result <= 1
-    assert result1 == 0
+    assert np.isclose(result1, 0, atol = 1e-9)
 
 
 if __name__ == "__main__":

--- a/tests/metrics/test_jsd.py
+++ b/tests/metrics/test_jsd.py
@@ -40,8 +40,9 @@ def test_jsd_discrete(dummy_data, test_data, jsd_instance):
 
     assert result >= 0
     assert result <= 1
-    assert np.isclose(result1, 0, atol = 1e-9)
-    assert np.isclose(result, result2, atol = 1e-9)
+    assert np.isclose(result1, 0, atol=1e-9)
+    assert np.isclose(result, result2, atol=1e-9)
+
 
 def test_jsd_continuous(dummy_data, test_data, jsd_instance):
     cols = ["feature_x"]
@@ -50,7 +51,7 @@ def test_jsd_continuous(dummy_data, test_data, jsd_instance):
 
     assert result >= 0
     assert result <= 1
-    assert np.isclose(result1, 0, atol = 1e-9)
+    assert np.isclose(result1, 0, atol=1e-9)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The changes in this PR aim to address the issue of Python's floating-point precision causing test failures. This PR sets an absolute tolerance of 1e-9 using the `np.isclose` function.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The original test cases were failing due to Python's floating-point precision issues. This was causing the test cases to fail **even though the results were theoretically correct**. 

By introducing absolute tolerances, we can make the test cases more robust and less likely to fail due to floating-point precision issues.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

The changes have been tested using testing cases.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Maintenance (no change in code, maintain the project's CI, docs, etc.)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.