### PR TITLE
Update NonValueTransformer's Default Setting and Handle Custom Fill Values

### DIFF
--- a/sdgx/data_processors/transformers/nan.py
+++ b/sdgx/data_processors/transformers/nan.py
@@ -51,9 +51,14 @@ class NonValueTransformer(Transformer):
         """
         logger.info("NonValueTransformer Fitted.")
 
+        for key, value in kwargs.items():
+            if key == 'fill_na_value':
+                if not isinstance(value, str):  
+                    raise ValueError("fill_na_value must be of type <str>")
+                self.fill_na_value = value
+        
         self.fitted = True
-
-        return
+            
 
     def convert(self, raw_data: DataFrame) -> DataFrame:
         """

--- a/sdgx/data_processors/transformers/nan.py
+++ b/sdgx/data_processors/transformers/nan.py
@@ -37,7 +37,7 @@ class NonValueTransformer(Transformer):
     """
     A boolean flag indicating whether to drop rows with missing values or fill them with `fill_na_value`.
 
-    If `True`, rows with missing values will be dropped. 
+    If `True`, rows with missing values will be dropped.
     If `False`, missing values will be filled with `fill_na_value`.
 
     Currently, the default setting is False, which means rows with missing values are not dropped.
@@ -52,13 +52,12 @@ class NonValueTransformer(Transformer):
         logger.info("NonValueTransformer Fitted.")
 
         for key, value in kwargs.items():
-            if key == 'fill_na_value':
-                if not isinstance(value, str):  
+            if key == "fill_na_value":
+                if not isinstance(value, str):
                     raise ValueError("fill_na_value must be of type <str>")
                 self.fill_na_value = value
-        
+
         self.fitted = True
-            
 
     def convert(self, raw_data: DataFrame) -> DataFrame:
         """

--- a/sdgx/data_processors/transformers/nan.py
+++ b/sdgx/data_processors/transformers/nan.py
@@ -33,11 +33,14 @@ class NonValueTransformer(Transformer):
     If `drop_na` is set to `False`, this value will be used to fill missing values in the data.
     """
 
-    drop_na = True
+    drop_na = False
     """
     A boolean flag indicating whether to drop rows with missing values or fill them with `fill_na_value`.
 
-    If `True`, rows with missing values will be dropped. If `False`, missing values will be filled with `fill_na_value`.
+    If `True`, rows with missing values will be dropped. 
+    If `False`, missing values will be filled with `fill_na_value`.
+
+    Currently, the default setting is False, which means rows with missing values are not dropped.
     """
 
     def fit(self, metadata: Metadata | None = None, **kwargs: dict[str, Any]):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The changes involve updating the `NonValueTransformer` class within the `sdgx/data_processors/transformers/nan.py` file. Specifically, the `drop_na` attribute is updated to default to `False`, indicating that rows with missing values will not be dropped by default. Additionally, a new functionality is introduced to handle a custom `fill_na_value` passed through `kwargs` during the `fit` method. This value must be of type `str`, and if not, a `ValueError` is raised.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change is required to enhance the flexibility of the `NonValueTransformer` class. By allowing users to specify a custom fill value for missing data, the transformer becomes more versatile and useful in scenarios where specific string values are preferred for filling missing data rather than dropping rows. 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
The changes have been tested by running unit tests that cover the `fit` and `convert` methods of the `NonValueTransformer` class. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Maintenance (no change in code, maintain the project's CI, docs, etc.)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.