### PR TITLE
`base_url` not included when request to gpt in SingleTableGPTModel

### DIFF
--- a/sdgx/models/LLM/single_table/gpt.py
+++ b/sdgx/models/LLM/single_table/gpt.py
@@ -141,6 +141,12 @@ class SingleTableGPTModel(LLMBaseModel):
             self.openai_API_url = os.getenv("OPENAI_URL")
             logger.debug("Get OPENAI_URL from ENV.")
 
+    def openai_client(self):
+        """
+        Generate a openai request client.
+        """
+        return openai.OpenAI(api_key=self.openai_API_key, base_url=self.openai_API_url)
+
     def ask_gpt(self, question, model=None):
         """
         Sends a question to the GPT model.
@@ -156,13 +162,11 @@ class SingleTableGPTModel(LLMBaseModel):
             SynthesizerInitError: If the check method fails.
         """
         self.check()
-        api_key = self.openai_API_key
         if model:
             model = model
         else:
             model = self.gpt_model
-        openai.api_key = api_key
-        client = openai.OpenAI(api_key=api_key)
+        client = self.openai_client()
         logger.info(f"Ask GPT with temperature = {self.temperature}.")
         response = client.chat.completions.create(
             model=model,

--- a/tests/models/test_singletable_gpt.py
+++ b/tests/models/test_singletable_gpt.py
@@ -119,6 +119,18 @@ marital-status = Married-civ-spouse, capital-gain = 0, occupation = Craft-repair
 gpt_response_sample_count = [20, 15, 20, 5, 5]
 
 
+def test_singletable_gpt_model_openapi_setting(single_table_gpt_model: SingleTableGPTModel):
+    open_ai_key = "sk-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    open_ai_base = "https://api.mock.openai.base.com"
+    open_ai_model = "gpt-4o-mini"
+    single_table_gpt_model.set_openAI_settings(open_ai_base, open_ai_key)
+    single_table_gpt_model.gpt_model = open_ai_model
+    client = single_table_gpt_model.openai_client()
+    assert client.base_url == open_ai_base
+    assert client.api_key == open_ai_key
+    assert single_table_gpt_model.gpt_model == open_ai_model
+
+
 def test_singletable_gpt_model(
     single_table_gpt_model: SingleTableGPTModel,
     raw_data: pd.DataFrame,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I updated the way to obtain the OpenAI client in `sdgx/models/LLM/single_table/gpt.py` (for easier testing) and ensured that it can use the user-injected `base_url` parameter in requests.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It's a bug fix that ensures `base_url` included when the client makes a request to GPT.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I tested it by  `test_singletable_gpt_model_openapi_setting()`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Maintenance (no change in code, maintain the project's CI, docs, etc.)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.