### PR TITLE
Reduce the memory usage of Gaussian Copula training.

### DIFF
--- a/sdgx/models/components/optimize/sdv_copulas/data_transformer.py
+++ b/sdgx/models/components/optimize/sdv_copulas/data_transformer.py
@@ -1,0 +1,112 @@
+import numpy as np
+import pandas as pd
+
+from sdgx.models.components.sdv_ctgan.data_transformer import (
+    ColumnTransformInfo,
+    DataTransformer,
+    SpanInfo,
+)
+from sdgx.models.components.sdv_rdt.transformers import ClusterBasedNormalizer
+from sdgx.models.components.sdv_rdt.transformers.categorical import FrequencyEncoder
+
+# TODO(Enhance) - Use different type of Encoder for discrete, like ordered columns, high cardinality columns...
+
+
+class StatisticDataTransformer(DataTransformer):
+    """Data Transformer for statistical models like Gaussian Copula."""
+
+    def _fit_continuous(self, data):
+        """Train ClusterBasedNormalizer for continuous columns."""
+        column_name = data.columns[0]
+        gm = ClusterBasedNormalizer(model_missing_values=True, max_clusters=1)
+        gm.fit(data, column_name)
+
+        return ColumnTransformInfo(
+            column_name=column_name,
+            column_type="continuous",
+            transform=gm,
+            output_info=[SpanInfo(1, "tanh")],
+            output_dimensions=1,
+        )
+
+    def _transform_continuous(self, column_transform_info, data):
+        """Transform continuous column."""
+        gm = column_transform_info.transform
+        transformed = gm.transform(data)
+        return transformed[f"{data.columns[0]}.normalized"].to_numpy().reshape(-1, 1)
+
+    def _inverse_transform_continuous(self, column_transform_info, column_data, sigmas, st):
+        """Inverse transform continuous column."""
+        gm = column_transform_info.transform
+        column_name = column_transform_info.column_name
+
+        # Create dataframe
+        data = pd.DataFrame(
+            {
+                f"{column_name}.normalized": column_data.flatten(),
+                f"{column_name}.component": [0] * len(column_data),  # virtual component
+            }
+        )
+
+        if sigmas is not None:
+            data[f"{column_name}.normalized"] = np.random.normal(
+                data[f"{column_name}.normalized"], sigmas[st]
+            )
+
+        # Reverse data
+        result = gm.reverse_transform(data)
+
+        # Ensure correct column
+        if column_name in result.columns:
+            return result[column_name]
+        else:
+            # Try first column
+            return result.iloc[:, 0]
+
+    def _fit_discrete(self, data):
+        """Fit frequency encoder for discrete column."""
+        column_name = data.columns[0]
+        freq_encoder = FrequencyEncoder()
+        freq_encoder.fit(data, column_name)
+
+        # Save original unique values for inverse transform
+        self._discrete_values = (
+            {column_name: data[column_name].unique().tolist()}
+            if not hasattr(self, "_discrete_values")
+            else {**self._discrete_values, column_name: data[column_name].unique().tolist()}
+        )
+
+        return ColumnTransformInfo(
+            column_name=column_name,
+            column_type="discrete",
+            transform=freq_encoder,
+            output_info=[SpanInfo(1, "tanh")],
+            output_dimensions=1,
+        )
+
+    def _transform_discrete(self, column_transform_info, data):
+        """Transform discrete column using frequency encoding."""
+        freq_encoder = column_transform_info.transform
+        return freq_encoder.transform(data).to_numpy().reshape(-1, 1)
+
+    def _inverse_transform_discrete(self, column_transform_info, column_data):
+        """Inverse transform discrete column from frequency encoding."""
+        freq_encoder = column_transform_info.transform
+        column_name = column_transform_info.column_name
+
+        # Use frequency encoder to reverse transform
+        data = pd.DataFrame({column_name: column_data.flatten()})
+
+        # Get all possible category values
+        categories = freq_encoder.starts["category"].values
+
+        # Find the closest category for each frequency value
+        result = []
+        for val in data[column_name]:
+            # The index of the closest start point
+            starts = freq_encoder.starts.index.values
+            idx = np.abs(starts - val).argmin()
+            # Set which category does the closest start point belong to
+            result.append(categories[idx])
+
+        return pd.Series(result, index=data.index, dtype=freq_encoder.dtype)

--- a/sdgx/models/statistics/single_table/copula.py
+++ b/sdgx/models/statistics/single_table/copula.py
@@ -10,6 +10,9 @@ import sdgx.models.components.sdv_copulas as copulas
 from sdgx.data_loader import DataLoader
 from sdgx.data_models.metadata import Metadata
 from sdgx.exceptions import NonParametricError, SynthesizerInitError
+from sdgx.models.components.optimize.sdv_copulas.data_transformer import (
+    StatisticDataTransformer,
+)
 from sdgx.models.components.sdv_copulas import multivariate
 from sdgx.models.components.sdv_ctgan.data_transformer import DataTransformer
 from sdgx.models.components.sdv_rdt.transformers import OneHotEncoder
@@ -138,7 +141,7 @@ class GaussianCopulaSynthesizer(StatisticSynthesizerModel):
         self.metadata = metadata
 
         # load the original transformer
-        self._transformer = DataTransformer()
+        self._transformer = StatisticDataTransformer()
 
         # self._transformer.fit(processed_data, self.metadata[0])
         self._transformer.fit(processed_data, self.discrete_cols)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I added a new `data_transformer` and apply in **GaussianCopula**. 

In terms of effectiveness:

**Simplified continuous data processing**
- Use a single normal distribution instead of multiple Gaussian distributions.
- Smaller output dimension (1D vs multidimensional).

**Different discrete data encoding**
- Use frequency encoding instead of one-hot encoding.
- Significantly reduces the output dimension.

**More suitable for statistical models**
- Outputs simpler numerical representations that retain the statistical properties of the data.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See Issue : https://github.com/hitsz-ids/synthetic-data-generator/issues/194
Currently, training Gaussian models on high-cardinality discrete data encounters memory issues during training, which is identified as being caused by sharing One-Hot encoding with CTGAN. For statistical models, it is proposed to use frequency-based encoding here, which will significantly reduce memory consumption and speed up the fitting process.



## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Performance test cases can consume a lot of time. 

I have used `memray` to test this performance issue, and the memory reduced from over 30 GB to within 3 GB.

This was a memory result test for issue original data model fit:
![iShot_2024-11-06_14 33 16](https://github.com/user-attachments/assets/769713b2-c575-4d96-9d00-a5878eec6042)

This was a result quality evaluate for original data(head 1000 lines) and sample (1000 lines), evaluate by `sdmetrics`
```bash
Generating report ...

(1/2) Evaluating Column Shapes: |██████████| 134/134 [00:00<00:00, 569.54it/s]|
Column Shapes Score: 83.49%

(2/2) Evaluating Column Pair Trends: |██████████| 8911/8911 [03:26<00:00, 43.14it/s]| 
Column Pair Trends Score: 73.19%

Overall Score (Average): 78.34%

             Property     Score
0       Column Shapes  0.834902
1  Column Pair Trends  0.731938
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Maintenance (no change in code, maintain the project's CI, docs, etc.)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.