### PR TITLE
Handling fixed column relationships by `specific_combinations` and `SpecificCombinationTransformer`.

### DIFF
--- a/docs/source/user_guides/index.rst
+++ b/docs/source/user_guides/index.rst
@@ -11,5 +11,6 @@ The Guides for users section includes SDG usage for different scenarios.
         Use CLI directly <cli>
         Use SDG as a library <library>
         Synthetic single-table data <single_table>
+        Synthetic single-table data with specific_combinations <single_table_column_combinations>
         Synthetic multi-table data <multi_table>
         Evaluation synthetic data <evaluation>

--- a/docs/source/user_guides/single_table_column_combinations.rst
+++ b/docs/source/user_guides/single_table_column_combinations.rst
@@ -1,0 +1,43 @@
+Synthetic single-table data with specific_combinations
+==========================================
+
+
+.. code-block:: python
+
+    import pandas as pd
+
+    from sdgx.data_connectors.csv_connector import CsvConnector
+    from sdgx.data_models.metadata import Metadata
+    from sdgx.models.ml.single_table.ctgan import CTGANSynthesizerModel
+    from sdgx.synthesizer import Synthesizer
+    from sdgx.utils import download_demo_data
+
+    dataset_csv = download_demo_data()
+    data_connector = CsvConnector(path=dataset_csv)
+
+    # Specific the fixed column combinations.
+    # It can be specified multiple combinations by different tuples. Here we only specify one.
+    metadata = Metadata.from_dataframe(pd.read_csv(dataset_csv))
+    combinations = {("education", "educational-num")}
+    metadata.update({"specific_combinations": combinations})
+
+    synthesizer = Synthesizer(
+        model=CTGANSynthesizerModel(epochs=1),  # For quick demo
+        data_connector=data_connector,
+        metadata=metadata
+    )
+    synthesizer.fit()
+    sampled_data = synthesizer.sample(1000)
+    synthesizer.cleanup()  # Clean all cache
+
+
+    from sdgx.metrics.column.jsd import JSD
+
+    JSD = JSD()
+
+
+    selected_columns = ["workclass"]
+    isDiscrete = True
+    metrics = JSD.calculate(data_connector.read(), sampled_data, selected_columns, isDiscrete)
+
+    print("JSD metric of column %s: %g" % (selected_columns[0], metrics))

--- a/sdgx/data_processors/manager.py
+++ b/sdgx/data_processors/manager.py
@@ -46,6 +46,7 @@ class DataProcessorManager(Manager):
     preset_defalut_processors = [
         p.lower()
         for p in [
+            "SpecificCombinationTransformer",
             "FixedCombinationTransformer",
             "NonValueTransformer",
             "OutlierTransformer",

--- a/sdgx/data_processors/transformers/fixed_combination.py
+++ b/sdgx/data_processors/transformers/fixed_combination.py
@@ -58,19 +58,20 @@ class FixedCombinationTransformer(Transformer):
     If true, needn't running this auto detect transform.
     """
 
-    is_exist_fixed_combinations: bool
-    """
-    A boolean that flag if inspector have inspected some fixed combinations.
-    If False, needn't running this auto detect transform.
-    """
-
     def __init__(self):
         super().__init__()
         self.fixed_combinations: dict[str, set[str]] = {}
         self.simplified_fixed_combinations: dict[str, set[str]] = {}
         self.column_mappings: dict[(str, str), dict[str, str]] = {}
         self.is_been_specified = False
-        self.is_exist_fixed_combinations = False
+
+    @property
+    def is_exist_fixed_combinations(self) -> bool:
+        """
+        A boolean that flag if inspector have inspected some fixed combinations.
+        If False, needn't running this auto detect transform.
+        """
+        return bool(self.fixed_combinations)
 
     def fit(self, metadata: Metadata | None = None, **kwargs: dict[str, Any]):
         """Fit the transformer and save the relationships between columns.
@@ -89,11 +90,10 @@ class FixedCombinationTransformer(Transformer):
 
         # Check if exist fixed combinations, if not exist, needn't run this auto-detect transform.
         self.fixed_combinations = metadata.get("fixed_combinations")
-        if self.fixed_combinations:
+        if not self.is_exist_fixed_combinations:
             logger.info(
                 "Fit data using FixedCombinationTransformer(not existed)... Finished (No action)."
             )
-            self.is_exist_fixed_combinations = False
             self.fitted = True
             return
 
@@ -119,7 +119,6 @@ class FixedCombinationTransformer(Transformer):
 
         self.simplified_fixed_combinations = simplified_fixed_combinations
         self.has_column_mappings = False
-        self.is_exist_fixed_combinations = True
         self.fitted = True
 
     def convert(self, raw_data: pd.DataFrame) -> pd.DataFrame:

--- a/sdgx/data_processors/transformers/fixed_combination.py
+++ b/sdgx/data_processors/transformers/fixed_combination.py
@@ -89,7 +89,7 @@ class FixedCombinationTransformer(Transformer):
             return
 
         # Check if exist fixed combinations, if not exist, needn't run this auto-detect transform.
-        self.fixed_combinations = metadata.get("fixed_combinations")
+        self.fixed_combinations = metadata.get("fixed_combinations") or dict()
         if not self.is_exist_fixed_combinations:
             logger.info(
                 "Fit data using FixedCombinationTransformer(not existed)... Finished (No action)."

--- a/sdgx/data_processors/transformers/fixed_combination.py
+++ b/sdgx/data_processors/transformers/fixed_combination.py
@@ -79,8 +79,7 @@ class FixedCombinationTransformer(Transformer):
             metadata (Metadata): Metadata object
         """
         # Check if exist specific combinations by user. If True, needn't run this auto-detect transform.
-        specific_combinations = metadata.get("specific_combinations")
-        if specific_combinations is not None and len(specific_combinations) > 0:
+        if metadata.get("specific_combinations"):
             logger.info(
                 "Fit data using FixedCombinationTransformer(been specified)... Finished (No action)."
             )
@@ -90,7 +89,7 @@ class FixedCombinationTransformer(Transformer):
 
         # Check if exist fixed combinations, if not exist, needn't run this auto-detect transform.
         self.fixed_combinations = metadata.get("fixed_combinations")
-        if self.fixed_combinations is not None and len(self.fixed_combinations) > 0:
+        if self.fixed_combinations:
             logger.info(
                 "Fit data using FixedCombinationTransformer(not existed)... Finished (No action)."
             )

--- a/sdgx/data_processors/transformers/fixed_combination.py
+++ b/sdgx/data_processors/transformers/fixed_combination.py
@@ -15,31 +15,62 @@ class FixedCombinationTransformer(Transformer):
     """
     A transformer that handles columns with fixed combinations in a DataFrame.
 
-    This transformer identifies and processes columns that have fixed relationships (high covariance) in a given DataFrame.
-    It can remove these columns during the conversion process and restore them during the reverse conversion process.
+    This transformer goal to auto identifies and processes columns that have fixed relationships (high covariance) in
+    a given DataFrame.
 
-    Attributes:
-        fixed_combinations (dict[str, set[str]]): A dictionary mapping column names to sets of column names that have fixed relationships with them.
+    The relationships between columns include:
+      - Numerical function relationships: assess them based on covariance between the columns.
+      - Categorical mapping relationships: check for duplicate values for each column.
+
+    Note that we support one-to-one mappings between columns now, and each corresponding relationship will not
+    include duplicate columns.
+
+    For example:
+    we detect that,
+    1 numerical relationship: (key1, Value1, Value2)
+    3 one-to-one relationships: (key1, Key2) , (Category1, Category2)
+
+    | Key1 | Key2 | Category1 | Category2 | Value1 | Value2 |
+    | :--: | :--: | :-------: | :-------: | :----: | :----: |
+    |  1   |  A   |   1001   |   Apple   |   10   |   20   |
+    |  2   |  B   |   1002   | Broccoli  |   15   |   30   |
+    |  2   |  B   |   1001   |  Apple   |   20   |   20   |
+    """
+
+    fixed_combinations: dict[str, set[str]]
+    """
+    A dictionary mapping column names to sets of column names that have fixed relationships with them.
+    """
+
+    simplified_fixed_combinations: dict[str, set[str]]
+    """
+    A dictionary mapping column names to sets of column names that have fixed relationships with them.
+    """
+
+    column_mappings: dict[(str, str), dict[str, str]]
+    """
+    A dictionary mapping tuples of column names to dictionaries of value mappings.
+    """
+
+    is_been_specified: bool
+    """
+    A boolean that flag if exist specific combinations by user.
+    If true, needn't running this auto detect transform.
+    """
+
+    is_exist_fixed_combinations: bool
+    """
+    A boolean that flag if inspector have inspected some fixed combinations.
+    If False, needn't running this auto detect transform.
     """
 
     def __init__(self):
-        super().__init__()  # Call the parent class's initialization method
-        # Initialize the variable in the initialization method
-
+        super().__init__()
         self.fixed_combinations: dict[str, set[str]] = {}
-        """
-        A dictionary mapping column names to sets of column names that have fixed relationships with them.
-        """
-
         self.simplified_fixed_combinations: dict[str, set[str]] = {}
-        """
-        A dictionary mapping column names to sets of column names that have fixed relationships with them.
-        """
-
         self.column_mappings: dict[(str, str), dict[str, str]] = {}
-        """
-        A dictionary mapping tuples of column names to dictionaries of value mappings.
-        """
+        self.is_been_specified = False
+        self.is_exist_fixed_combinations = False
 
     def fit(self, metadata: Metadata | None = None, **kwargs: dict[str, Any]):
         """Fit the transformer and save the relationships between columns.
@@ -47,9 +78,27 @@ class FixedCombinationTransformer(Transformer):
         Args:
             metadata (Metadata): Metadata object
         """
-        self.fixed_combinations = metadata.get("fixed_combinations")
+        # Check if exist specific combinations by user. If True, needn't run this auto-detect transform.
+        specific_combinations = metadata.get("specific_combinations")
+        if specific_combinations is not None and len(specific_combinations) > 0:
+            logger.info(
+                "Fit data using FixedCombinationTransformer(been specified)... Finished (No action)."
+            )
+            self.is_been_specified = True
+            self.fitted = True
+            return
 
-        # simplify the fixed_combinations, remove the symmetric and duplicate combinations
+        # Check if exist fixed combinations, if not exist, needn't run this auto-detect transform.
+        self.fixed_combinations = metadata.get("fixed_combinations")
+        if self.fixed_combinations is not None and len(self.fixed_combinations) > 0:
+            logger.info(
+                "Fit data using FixedCombinationTransformer(not existed)... Finished (No action)."
+            )
+            self.is_exist_fixed_combinations = False
+            self.fitted = True
+            return
+
+        # Simplify the fixed_combinations, remove the symmetric and duplicate combinations
         simplified_fixed_combinations = {}
         seen = set()
 
@@ -61,7 +110,7 @@ class FixedCombinationTransformer(Transformer):
             )
 
         for base_col, related_cols in self.fixed_combinations.items():
-            # create a immutable set of base_col and related_cols
+            # create an immutable set of base_col and related_cols
             combination = frozenset([base_col]) | frozenset(related_cols)
 
             # if the combination has not been seen, add it to the simplified_fixed_combinations
@@ -70,9 +119,8 @@ class FixedCombinationTransformer(Transformer):
                 seen.add(combination)
 
         self.simplified_fixed_combinations = simplified_fixed_combinations
-
         self.has_column_mappings = False
-
+        self.is_exist_fixed_combinations = True
         self.fitted = True
 
     def convert(self, raw_data: pd.DataFrame) -> pd.DataFrame:
@@ -83,10 +131,8 @@ class FixedCombinationTransformer(Transformer):
         to optimize performance.
 
         NOTE:
-            TODO-Enhance-Designed configuration interface. Use the user's configured Constrain if provided.
             TODO-Enhance-Refactor Inspector by chain-of-responsibility, base one-to-one on Identified discrete_columns.
             The current implementation has space for optimization:
-            - If column_mappings already exist, no recalculation is performed
             - The column_mappings definition depends on the first batch of data from the DataLoader
             - This might miss some edge cases where column relationships are very comprehensive
               (e.g., some column correspondences might only appear in later batches)
@@ -101,6 +147,18 @@ class FixedCombinationTransformer(Transformer):
         Returns:
             pd.DataFrame: The processed DataFrame (unchanged in this implementation)
         """
+
+        if self.is_been_specified:
+            logger.info(
+                "Converting data using FixedCombinationTransformer(been specified)... Finished (No action)."
+            )
+            return raw_data
+
+        if not self.is_exist_fixed_combinations:
+            logger.info(
+                "Converting data using FixedCombinationTransformer(not existed)... Finished (No action)."
+            )
+            return raw_data
 
         if self.has_column_mappings:
             logger.info(
@@ -157,6 +215,17 @@ class FixedCombinationTransformer(Transformer):
         Returns:
             pd.DataFrame: The DataFrame with original values restored based on the defined mappings.
         """
+        if self.is_been_specified:
+            logger.info(
+                "Reverse converting data using FixedCombinationTransformer(been specified)... Finished (No action)."
+            )
+            return processed_data
+
+        if not self.is_exist_fixed_combinations:
+            logger.info(
+                "Reverse converting data using FixedCombinationTransformer(not existed)... Finished (No action)."
+            )
+            return processed_data
 
         result_df = processed_data.copy()
 

--- a/sdgx/data_processors/transformers/specific_combination.py
+++ b/sdgx/data_processors/transformers/specific_combination.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from typing import Dict, List, Set
+
+import pandas as pd
+
+from sdgx.data_loader import DataLoader
+from sdgx.data_models.metadata import Metadata
+from sdgx.data_processors.extension import hookimpl
+from sdgx.data_processors.transformers.base import Transformer
+from sdgx.utils import logger
+
+"""
+Make sure that user's specific combination are correct in sample data.
+"""
+
+
+class SpecificCombinationTransformer(Transformer):
+    """
+    Define a list where each element is a set containing string type column names
+    """
+
+    column_groups: List[Set[str]]
+
+    """
+    Define a dictionary variable `mappings` where the keys are frozensets and the values are pandas DataFrame objects
+    """
+    mappings: Dict[frozenset, pd.DataFrame]
+
+    def __init__(self):
+        self.column_groups: List[Set[str]] = []
+        self.mappings: Dict[frozenset, pd.DataFrame] = {}
+
+    def fit(self, metadata: Metadata | None = None, tabular_data: DataLoader | pd.DataFrame = None):
+        """
+        Study the combination relationships and value mapping of columns.
+        """
+
+        # TODO-2024/11/14 - Defined how metadata passing the specific combination
+        df = tabular_data
+        column_lists = metadata.get("specific_combinations")
+        if column_lists is None or len(column_lists) == 0:
+            logger.warning("No specific combination information found in metadata.")
+            return
+
+        self.column_groups = [set(cols) for cols in column_lists]
+
+        # Create a mapping relationship for each group of columns
+        for group in self.column_groups:
+            group_df = df[list(group)].drop_duplicates()
+            self.mappings[frozenset(group)] = group_df
+
+        self.fitted = True
+        logger.info("SpecificCombinationTransformer Fitted.")
+
+    def convert(self, raw_data: pd.DataFrame) -> pd.DataFrame:
+        logger.info("SpecificCombinationTransformer convert doing nothing...")
+        return super().convert(raw_data)
+
+    def reverse_convert(self, processed_data: pd.DataFrame) -> pd.DataFrame:
+        """
+        Ensure that the data conforms to the learned mapping relationships
+        """
+        result_df = processed_data.copy()
+
+        for group in self.column_groups:
+            group_mapping = self.mappings[frozenset(group)]
+            group_cols = list(group)
+
+            # Check and correct each row
+            for idx in range(len(result_df)):
+                row_values = result_df.loc[idx, group_cols].to_dict()
+
+                # Find the best matching row in the mapping table
+                best_match = None
+                max_matches = -1
+
+                for _, mapping_row in group_mapping.iterrows():
+                    matches = sum(row_values[col] == mapping_row[col] for col in group_cols)
+                    if matches > max_matches:
+                        max_matches = matches
+                        best_match = mapping_row
+
+                # Update the current row using the best match
+                if best_match is not None:
+                    result_df.loc[idx, group_cols] = best_match
+
+        return result_df
+
+
+@hookimpl
+def register(manager):
+    manager.register("SpecificCombinationTransformer", SpecificCombinationTransformer)

--- a/sdgx/data_processors/transformers/specific_combination.py
+++ b/sdgx/data_processors/transformers/specific_combination.py
@@ -10,57 +10,117 @@ from sdgx.data_processors.extension import hookimpl
 from sdgx.data_processors.transformers.base import Transformer
 from sdgx.utils import logger
 
-"""
-Make sure that user's specific combination are correct in sample data.
-"""
-
 
 class SpecificCombinationTransformer(Transformer):
+
+    # // TODO-2024/11/15 Optimize performance of reverse_convert()
+
+    """
+    A transformer used to handle specific combinations of columns in tabular data.
+
+    The relationships between columns can be quite complex. Currently, we introduced `FixedCombinationTransformer`
+    is not capable of comprehensive automatic detection. This transformer allows users to manually specify the
+    mapping relationships between columns, specifically for multiple corresponding relationships. Users can define
+    multiple groups, with each group supporting multiple columns. The transformer will record the combination values
+    of each column, and in the `reverse_convert()`, it will restore any mismatched combinations from the recorded
+    relationships.
+
+    For example:
+
+    | Category A | Category B | Category C | Category D | Category E |
+    | :--------: | :--------: | :--------: | :--------: | :--------: |
+    |     A1     |     B1     |     C1     |     D1     |     E1     |
+    |     A1     |     B1     |     C2     |     D2     |     E2     |
+    |     A2     |     B2     |     C1     |     D1     |     E3     |
+
+    Here user can specific combination like (Category A, Category B), (Category C, Category D, Category E).
+
+    For now, the `specific_combinations` passing by `Metadata`
+
+    """
+
+    column_groups: List[Set[str]]
     """
     Define a list where each element is a set containing string type column names
     """
 
-    column_groups: List[Set[str]]
-
+    mappings: Dict[frozenset, pd.DataFrame]
     """
     Define a dictionary variable `mappings` where the keys are frozensets and the values are pandas DataFrame objects
     """
-    mappings: Dict[frozenset, pd.DataFrame]
+
+    specified: bool
+    """
+    Define a boolean that flag if user specified the combination, if true, that handle the `specific_combinations`
+    """
 
     def __init__(self):
         self.column_groups: List[Set[str]] = []
         self.mappings: Dict[frozenset, pd.DataFrame] = {}
+        self.specified = False
 
     def fit(self, metadata: Metadata | None = None, tabular_data: DataLoader | pd.DataFrame = None):
         """
         Study the combination relationships and value mapping of columns.
-        """
 
-        # TODO-2024/11/14 - Defined how metadata passing the specific combination
-        df = tabular_data
-        column_lists = metadata.get("specific_combinations")
-        if column_lists is None or len(column_lists) == 0:
-            logger.warning("No specific combination information found in metadata.")
+        Args:
+            metadata: Metadata containing information about specific column combinations.
+            tabular_data: The tabular data to be fitted, can be a DataLoader object or a pandas DataFrame.
+        """
+        specific_combinations = metadata.get("specific_combinations")
+        if specific_combinations is None or len(specific_combinations) == 0:
+            logger.info(
+                "Fit data using SpecificCombinationTransformer(No specified)... Finished (No action)."
+            )
+            self.fitted = True
             return
 
-        self.column_groups = [set(cols) for cols in column_lists]
-
         # Create a mapping relationship for each group of columns
+        df = tabular_data
+        self.column_groups = [set(cols) for cols in specific_combinations]
         for group in self.column_groups:
             group_df = df[list(group)].drop_duplicates()
             self.mappings[frozenset(group)] = group_df
 
         self.fitted = True
+        self.specified = True
         logger.info("SpecificCombinationTransformer Fitted.")
 
     def convert(self, raw_data: pd.DataFrame) -> pd.DataFrame:
+        """
+        Convert the raw data based on the learned mapping relationships.
+
+        Args:
+           raw_data: The raw data to be converted.
+
+        Returns:
+           The converted data.
+        """
+        if not self.specified:
+            logger.info(
+                "Converting data using SpecificCombinationTransformer(No specified)... Finished (No action)."
+            )
+            return super().convert(raw_data)
+
         logger.info("SpecificCombinationTransformer convert doing nothing...")
         return super().convert(raw_data)
 
     def reverse_convert(self, processed_data: pd.DataFrame) -> pd.DataFrame:
         """
-        Ensure that the data conforms to the learned mapping relationships
+        Reverse convert the processed data to ensure it conforms to the original format.
+
+        Args:
+            processed_data: The processed data to be reverse converted.
+
+        Returns:
+            The reverse converted data.
         """
+        if not self.specified:
+            logger.info(
+                "Reverse converting data using SpecificCombinationTransformer(No specified)... Finished (No action)."
+            )
+            return processed_data
+
         result_df = processed_data.copy()
 
         for group in self.column_groups:

--- a/tests/data_processors/transformers/test_transformers_specific_combination.py
+++ b/tests/data_processors/transformers/test_transformers_specific_combination.py
@@ -52,22 +52,16 @@ def expected_data():
 def test_specific_combination_transformer(train_data, test_data, expected_data):
     transformer = SpecificCombinationTransformer()
     metadata = Metadata.from_dataframe(train_data)
-    # TODO-2024/11/14 Here we should support a easy way to assign this param
-    # column_groups = [
-    #     ['price_usd', 'price_cny', 'price_eur'],
-    #     ['size_cm', 'size_inch', 'size_m']
-    # ]
-    # column_groups = tuple(column_groups)
 
     # Turn parameter into a tuple
-    price_group = tuple(["price_usd", "price_cny", "price_eur"])
-    size_group = tuple(["size_cm", "size_inch", "size_m"])
-    column_groups = {price_group, size_group}
-    metadata_dict = {"specific_combinations": column_groups}
-    metadata.update(metadata_dict)
-
-    metadata_dict = {"specific_combination": column_groups}
-    metadata.update(metadata_dict)
+    metadata.update(
+        {
+            "specific_combinations": {
+                ("price_usd", "price_cny", "price_eur"),
+                ("size_cm", "size_inch", "size_m"),
+            }
+        }
+    )
     transformer.fit(metadata=metadata, tabular_data=train_data)
     result = transformer.reverse_convert(test_data)
     pd.testing.assert_frame_equal(result, expected_data, check_dtype=False)

--- a/tests/data_processors/transformers/test_transformers_specific_combination.py
+++ b/tests/data_processors/transformers/test_transformers_specific_combination.py
@@ -1,0 +1,73 @@
+import pandas as pd
+import pytest
+
+from sdgx.data_models.metadata import Metadata
+from sdgx.data_processors.transformers.specific_combination import (
+    SpecificCombinationTransformer,
+)
+
+
+@pytest.fixture
+def train_data():
+    return pd.DataFrame(
+        {
+            "price_usd": [100, 200, 300],
+            "price_cny": [700, 1400, 2100],
+            "price_eur": [90, 180, 270],
+            "size_cm": [10, 20, 30],
+            "size_inch": [3.94, 7.87, 11.81],
+            "size_m": [0.1, 0.2, 0.3],
+        }
+    )
+
+
+@pytest.fixture
+def test_data():
+    return pd.DataFrame(
+        {
+            "price_usd": [200, 200, 100],
+            "price_cny": [1400, 1400, 2100],
+            "price_eur": [90, 270, 270],
+            "size_cm": [10, 20, 20],
+            "size_inch": [3.94, 7.87, 11.81],
+            "size_m": [0.1, 0.3, 0.3],
+        }
+    )
+
+
+@pytest.fixture
+def expected_data():
+    return pd.DataFrame(
+        {
+            "price_usd": [200, 200, 300],
+            "price_cny": [1400, 1400, 2100],
+            "price_eur": [180, 180, 270],
+            "size_cm": [10, 20, 30],
+            "size_inch": [3.94, 7.87, 11.81],
+            "size_m": [0.1, 0.2, 0.3],
+        }
+    )
+
+
+def test_specific_combination_transformer(train_data, test_data, expected_data):
+    transformer = SpecificCombinationTransformer()
+    metadata = Metadata.from_dataframe(train_data)
+    # TODO-2024/11/14 Here we should support a easy way to assign this param
+    # column_groups = [
+    #     ['price_usd', 'price_cny', 'price_eur'],
+    #     ['size_cm', 'size_inch', 'size_m']
+    # ]
+    # column_groups = tuple(column_groups)
+
+    # Turn parameter into a tuple
+    price_group = tuple(["price_usd", "price_cny", "price_eur"])
+    size_group = tuple(["size_cm", "size_inch", "size_m"])
+    column_groups = {price_group, size_group}
+    metadata_dict = {"specific_combinations": column_groups}
+    metadata.update(metadata_dict)
+
+    metadata_dict = {"specific_combination": column_groups}
+    metadata.update(metadata_dict)
+    transformer.fit(metadata=metadata, tabular_data=train_data)
+    result = transformer.reverse_convert(test_data)
+    pd.testing.assert_frame_equal(result, expected_data, check_dtype=False)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I haved added a new `SpecificCombinationTransformer`, and modifed `FixedCombinationTransformer`. And a test case for `SpecificCombinationTransformer`.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`SpecificCombinationTransformer` would transforming when user specified some column-mapping combination, and `FixedCombinationTransformer` would not running at the same time.

I make `FixedCombinationTransformer` as default column-mapping combination detector and transformer.As for `SpecificCombinationTransformer`, it would transforming when user specified some column-mapping combinations, make sure the sample data column-mapping adhere to the specified combinations. At the same time,  `FixedCombinationTransformer` would not run transforming when `SpecificCombinationTransformer` activated.


## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
See test case.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Maintenance (no change in code, maintain the project's CI, docs, etc.)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.