### PR TITLE
Integrate `GaussianCopula` model into the `Synthesizer`.

### DIFF
--- a/sdgx/models/statistics/single_table/base.py
+++ b/sdgx/models/statistics/single_table/base.py
@@ -2,24 +2,28 @@
 # Which is Lincensed by MIT License
 
 import os
-from copy import deepcopy
-from typing import List, Optional
 
 import numpy as np
 import torch
 
+from sdgx.data_loader import DataLoader
+from sdgx.data_models.metadata import Metadata
+from sdgx.models.base import SynthesizerModel
 
-class StatisticSynthesizerModel:
+
+class StatisticSynthesizerModel(SynthesizerModel):
     random_states = None
 
-    def __init__(self, transformer=None, sampler=None) -> None:
+    def __init__(self, transformer=None, sampler=None, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._generator = None
         self.model = None
         self.status = "UNFINED"
         self.model_type = "MODEL_TYPE_UNDEFINED"
         # self.epochs = epochs
         self._device = "CPU"
 
-    def fit(self, input_df, discrete_cols: Optional[List] = None):
+    def fit(self, metadata: Metadata, dataloader: DataLoader, *args, **kwargs):
         raise NotImplementedError
 
     def set_device(self, device):

--- a/sdgx/models/statistics/single_table/copula.py
+++ b/sdgx/models/statistics/single_table/copula.py
@@ -9,16 +9,13 @@ import scipy
 import sdgx.models.components.sdv_copulas as copulas
 from sdgx.data_loader import DataLoader
 from sdgx.data_models.metadata import Metadata
-from sdgx.exceptions import NonParametricError, SynthesizerInitError
+from sdgx.exceptions import NonParametricError
 from sdgx.models.components.optimize.sdv_copulas.data_transformer import (
     StatisticDataTransformer,
 )
 from sdgx.models.components.sdv_copulas import multivariate
-from sdgx.models.components.sdv_ctgan.data_transformer import DataTransformer
-from sdgx.models.components.sdv_rdt.transformers import OneHotEncoder
 from sdgx.models.components.utils import (
     flatten_dict,
-    log_numerical_distributions_error,
     unflatten_dict,
     validate_numerical_distributions,
 )
@@ -27,7 +24,7 @@ from sdgx.models.statistics.single_table.base import StatisticSynthesizerModel
 LOGGER = logging.getLogger(__name__)
 
 
-class GaussianCopulaSynthesizer(StatisticSynthesizerModel):
+class GaussianCopulaSynthesizerModel(StatisticSynthesizerModel):
     """Model wrapping ``copulas.multivariate.GaussianMultivariate`` copula.
 
     Args:

--- a/tests/models/test_copula.py
+++ b/tests/models/test_copula.py
@@ -1,10 +1,7 @@
-from pathlib import Path
-
 import pandas as pd
 import pytest
 
-from sdgx.models.statistics.single_table.copula import GaussianCopulaSynthesizer
-from sdgx.utils import get_demo_single_table
+from sdgx.models.statistics.single_table.copula import GaussianCopulaSynthesizerModel
 
 
 @pytest.fixture
@@ -13,7 +10,7 @@ def dummy_data(dummy_single_table_path):
 
 
 def test_gaussian_copula(dummy_single_table_metadata, dummy_single_table_data_loader):
-    model = GaussianCopulaSynthesizer()
+    model = GaussianCopulaSynthesizerModel()
     model.fit(dummy_single_table_metadata, dummy_single_table_data_loader)
 
     sampled_data = model.sample(10)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I have made GaussianCopula extended with `SynthesizerModel`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We could see that the **Core Data Pre-Post Process Pipeline** was triggered in `Synthesizer`, which meant data would not be processed if just instance a Model to sythetic data, you have to assign a model to `Synthesizer`. 

Now we support `model=GaussianCopulaSynthesizerModel()`, we could write code just like this:

```python
from sdgx.data_connectors.csv_connector import CsvConnector
from sdgx.models.ml.single_table.ctgan import CTGANSynthesizerModel
from sdgx.synthesizer import Synthesizer
from sdgx.utils import download_demo_data

# This will download demo data to ./dataset
dataset_csv = download_demo_data()

# Create data connector for csv file
data_connector = CsvConnector(path=dataset_csv)

# Initialize synthesizer, use GaussianCopula model
synthesizer = Synthesizer(
    model=GaussianCopulaSynthesizerModel(),  # For quick demo
    data_connector=data_connector,
)

# Fit the model
synthesizer.fit()

# Sample
sampled_data = synthesizer.sample(1000)
print(sampled_data)
```



## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Maintenance (no change in code, maintain the project's CI, docs, etc.)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.