### PR TITLE
添加补充了 _form_columns_description函数

### DIFF
--- a/sdgx/models/LLM/base.py
+++ b/sdgx/models/LLM/base.py
@@ -1,7 +1,9 @@
+import pandas as pd
+
 from sdgx.exceptions import SynthesizerInitError
 from sdgx.models.base import SynthesizerModel
 from sdgx.utils import logger
-import pandas as pd
+
 
 class LLMBaseModel(SynthesizerModel):
     """
@@ -87,7 +89,7 @@ class LLMBaseModel(SynthesizerModel):
             raise SynthesizerInitError("Duplicate data access type found.")
 
     def _form_columns_description(self):
-        
+
         df = self.raw_data  # 确保 self.raw_data 是一个 pandas.DataFrame
         desc_lines = []
 
@@ -96,17 +98,23 @@ class LLMBaseModel(SynthesizerModel):
             dtype = series.dtype
 
             if pd.api.types.is_numeric_dtype(dtype):
-                line = (f'Column "{col}": type {dtype}, '
-                        f'min {series.min()}, max {series.max()}, '
-                        f'mean {series.mean():.2f}, std {series.std():.2f}.')
+                line = (
+                    f'Column "{col}": type {dtype}, '
+                    f"min {series.min()}, max {series.max()}, "
+                    f"mean {series.mean():.2f}, std {series.std():.2f}."
+                )
             elif pd.api.types.is_datetime64_any_dtype(dtype):
-                line = (f'Column "{col}": type datetime, '
-                        f'from {series.min().strftime("%Y-%m-%d")}, '
-                        f'to {series.max().strftime("%Y-%m-%d")}.')
+                line = (
+                    f'Column "{col}": type datetime, '
+                    f'from {series.min().strftime("%Y-%m-%d")}, '
+                    f'to {series.max().strftime("%Y-%m-%d")}.'
+                )
             elif pd.api.types.is_categorical_dtype(series) or series.nunique() < 20:
                 values = series.unique()
-                line = (f'Column "{col}": type category, '
-                        f'{len(values)} categories: {list(values[:5])}{"..." if len(values) > 5 else ""}.')
+                line = (
+                    f'Column "{col}": type category, '
+                    f'{len(values)} categories: {list(values[:5])}{"..." if len(values) > 5 else ""}.'
+                )
             else:
                 line = f'Column "{col}": type {dtype}.'
 

--- a/sdgx/models/LLM/base.py
+++ b/sdgx/models/LLM/base.py
@@ -1,7 +1,7 @@
 from sdgx.exceptions import SynthesizerInitError
 from sdgx.models.base import SynthesizerModel
 from sdgx.utils import logger
-
+import pandas as pd
 
 class LLMBaseModel(SynthesizerModel):
     """
@@ -87,13 +87,32 @@ class LLMBaseModel(SynthesizerModel):
             raise SynthesizerInitError("Duplicate data access type found.")
 
     def _form_columns_description(self):
-        """
-        We believe that giving information about a column helps improve data quality.
+        
+        df = self.raw_data  # 确保 self.raw_data 是一个 pandas.DataFrame
+        desc_lines = []
 
-        Currently, we leave this function to Good First Issue until March 2024, if unclaimed we will implement it quickly.
-        """
+        for col in df.columns:
+            series = df[col]
+            dtype = series.dtype
 
-        raise NotImplementedError
+            if pd.api.types.is_numeric_dtype(dtype):
+                line = (f'Column "{col}": type {dtype}, '
+                        f'min {series.min()}, max {series.max()}, '
+                        f'mean {series.mean():.2f}, std {series.std():.2f}.')
+            elif pd.api.types.is_datetime64_any_dtype(dtype):
+                line = (f'Column "{col}": type datetime, '
+                        f'from {series.min().strftime("%Y-%m-%d")}, '
+                        f'to {series.max().strftime("%Y-%m-%d")}.')
+            elif pd.api.types.is_categorical_dtype(series) or series.nunique() < 20:
+                values = series.unique()
+                line = (f'Column "{col}": type category, '
+                        f'{len(values)} categories: {list(values[:5])}{"..." if len(values) > 5 else ""}.')
+            else:
+                line = f'Column "{col}": type {dtype}.'
+
+            desc_lines.append(line)
+
+        return "\n".join(desc_lines)
 
     def _form_message_with_offtable_features(self):
         """


### PR DESCRIPTION
### 📌 关联 Issue
问题 #142

### ✨ 提交说明
本次提交实现了 `LLMBaseModel` 中的 `_form_columns_description` 方法，旨在根据 `self.raw_data` 中的各列内容，生成适用于大语言模型（LLM）理解的自然语言描述信息，用于增强提示词质量。

该方法返回的描述内容包括但不限于：
- 列名及其数据类型（数值型、时间型、类别型等）
- 对于数值型列：最小值、最大值、平均值、标准差
- 对于时间型列：起始日期与结束日期
- 对于类别型列（或唯一值数量较少的列）：类别数量与部分示例值
- 其他类型：返回基本的数据类型信息

### 🧪 示例输出
当数据包含如下列时，方法输出示例为：
Column "age": type int64, min 18, max 60, mean 35.72, std 10.45.
Column "signup_date": type datetime, from 2021-01-01, to 2023-12-31.
Column "gender": type category, 2 categories: ['Male', 'Female'].

