### PR TITLE
feat: add MiniMax as LLM provider for synthetic data generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,11 @@ Infer new column data based on the existing data in the table and the knowledge 
 In addition to OpenAI GPT, SDG also supports [MiniMax](https://platform.minimax.io) as an LLM provider for synthetic data generation. MiniMax provides an OpenAI-compatible API with competitive pricing and strong performance.
 
 **Supported Models:**
-| Model | Description |
-|-------|-------------|
-| `MiniMax-M2.7` | Peak Performance. Ultimate Value. Master the Complex. |
-| `MiniMax-M2.7-highspeed` | Same performance, faster and more agile. |
+
+| Model                    | Description                                           |
+| ------------------------ | ----------------------------------------------------- |
+| `MiniMax-M2.7`           | Peak Performance. Ultimate Value. Master the Complex. |
+| `MiniMax-M2.7-highspeed` | Same performance, faster and more agile.              |
 
 **Quick Start:**
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Our current key achievements and timelines are as follows:
 
 For a long time, LLM has been used to understand and generate various types of data. In fact, LLM also has certain capabilities in tabular data generation. Also, it has some abilities that cannot be achieved by traditional (based on GAN methods or statistical methods) .
 
-Our `sdgx.models.LLM.single_table.gpt.SingleTableGPTModel` implements two new features:
+Our `sdgx.models.LLM.single_table.gpt.SingleTableGPTModel` and `sdgx.models.LLM.single_table.minimax.SingleTableMiniMaxModel` implement two new features:
 
 ### Synthetic data generation without Data
 
@@ -79,6 +79,31 @@ No training data is required, synthetic data can be generated based on metadata 
 Infer new column data based on the existing data in the table and the knowledge mastered by LLM, view in our <a href="https://colab.research.google.com/drive/1_chuTVZECpj5fklj-RAp7ZVrew8weLW_?usp=sharing" target="value"> colab example</a>.
 
 ![Off-Table feature inference](assets/LLM_Case_2.gif)
+
+### MiniMax LLM Support
+
+In addition to OpenAI GPT, SDG also supports [MiniMax](https://platform.minimax.io) as an LLM provider for synthetic data generation. MiniMax provides an OpenAI-compatible API with competitive pricing and strong performance.
+
+**Supported Models:**
+| Model | Description |
+|-------|-------------|
+| `MiniMax-M2.7` | Peak Performance. Ultimate Value. Master the Complex. |
+| `MiniMax-M2.7-highspeed` | Same performance, faster and more agile. |
+
+**Quick Start:**
+
+```python
+import os
+os.environ["MINIMAX_API_KEY"] = "your-minimax-api-key"
+
+from sdgx.models.LLM.single_table.minimax import SingleTableMiniMaxModel
+
+model = SingleTableMiniMaxModel()
+model.fit(raw_data)
+synthetic_data = model.sample(100)
+```
+
+For more information, see the [MiniMax API Documentation](https://platform.minimax.io/docs/api-reference/text-openai-api).
 
 ## 💫 Why SDG ?
 

--- a/sdgx/models/LLM/single_table/__init__.py
+++ b/sdgx/models/LLM/single_table/__init__.py
@@ -1,0 +1,2 @@
+from sdgx.models.LLM.single_table.gpt import SingleTableGPTModel  # noqa: F401
+from sdgx.models.LLM.single_table.minimax import SingleTableMiniMaxModel  # noqa: F401

--- a/sdgx/models/LLM/single_table/minimax.py
+++ b/sdgx/models/LLM/single_table/minimax.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from sdgx.exceptions import InitializationError
+from sdgx.models.LLM.single_table.gpt import SingleTableGPTModel
+from sdgx.utils import logger
+
+# MiniMax supported models
+MINIMAX_MODELS = ["MiniMax-M2.7", "MiniMax-M2.7-highspeed"]
+
+
+class SingleTableMiniMaxModel(SingleTableGPTModel):
+    """
+    Synthetic data generation model powered by MiniMax LLM.
+
+    MiniMax provides OpenAI-compatible API, so this model inherits from
+    SingleTableGPTModel and overrides the configuration to use MiniMax's
+    API endpoint and models.
+
+    Supported models:
+    - MiniMax-M2.7: Peak Performance. Ultimate Value. Master the Complex.
+    - MiniMax-M2.7-highspeed: Same performance, faster and more agile.
+
+    Environment variables:
+    - MINIMAX_API_KEY: API key for MiniMax (required)
+    - MINIMAX_API_URL: Custom base URL (optional, defaults to https://api.minimax.io/v1)
+
+    Usage::
+
+        from sdgx.models.LLM.single_table.minimax import SingleTableMiniMaxModel
+
+        model = SingleTableMiniMaxModel()
+        model.fit(raw_data)
+        synthetic_data = model.sample(100)
+
+    For more information, see: https://platform.minimax.io/docs/api-reference/text-openai-api
+    """
+
+    openai_API_url = "https://api.minimax.io/v1"
+    """
+    The base URL for MiniMax's OpenAI-compatible API.
+    """
+
+    gpt_model = "MiniMax-M2.7"
+    """
+    The default MiniMax model. Use 'MiniMax-M2.7-highspeed' for faster responses.
+    """
+
+    temperature = 1.0
+    """
+    MiniMax temperature must be in (0.0, 1.0]. Cannot be 0. Default is 1.0.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        if "temperature" in kwargs:
+            self.temperature = kwargs.pop("temperature")
+        super().__init__(*args, **kwargs)
+        self._get_minimax_setting_from_env()
+        self._clamp_temperature()
+
+    def _get_minimax_setting_from_env(self):
+        """
+        Retrieves MiniMax settings from environment variables.
+        Falls back to OPENAI_KEY/OPENAI_URL if MINIMAX_* vars are not set.
+        """
+        if os.getenv("MINIMAX_API_KEY"):
+            self.openai_API_key = os.getenv("MINIMAX_API_KEY")
+            logger.debug("Get MINIMAX_API_KEY from ENV.")
+        if os.getenv("MINIMAX_API_URL"):
+            self.openai_API_url = os.getenv("MINIMAX_API_URL")
+            logger.debug("Get MINIMAX_API_URL from ENV.")
+
+    def _clamp_temperature(self):
+        """
+        MiniMax requires temperature in (0.0, 1.0].
+        Clamp values outside this range.
+        """
+        if self.temperature <= 0:
+            self.temperature = 0.01
+            logger.warning("MiniMax does not support temperature=0, clamped to 0.01.")
+        elif self.temperature > 1.0:
+            self.temperature = 1.0
+            logger.warning("MiniMax temperature capped at 1.0.")
+
+    def _check_openAI_setting(self):
+        """
+        Checks if the MiniMax API settings are properly initialized.
+        """
+        if not self.openai_API_url:
+            raise InitializationError("MiniMax API URL not found.")
+        if not self.openai_API_key:
+            raise InitializationError(
+                "MiniMax API key not found. "
+                "Set MINIMAX_API_KEY environment variable or call "
+                "set_minimax_settings(API_key='your-key')."
+            )
+        logger.debug("MiniMax setting check passed.")
+
+    def set_minimax_settings(self, API_url="https://api.minimax.io/v1", API_key=""):
+        """
+        Sets the MiniMax API settings.
+
+        Args:
+            API_url (str): The MiniMax API URL. Defaults to "https://api.minimax.io/v1".
+            API_key (str): The MiniMax API key.
+        """
+        self.openai_API_url = API_url
+        self.openai_API_key = API_key
+        self._set_openAI()
+
+    def ask_gpt(self, question, model=None):
+        """
+        Sends a question to the MiniMax model via OpenAI-compatible API.
+
+        Ensures temperature is within MiniMax's valid range before making the call.
+        """
+        self._clamp_temperature()
+        return super().ask_gpt(question, model=model)

--- a/tests/models/test_singletable_minimax.py
+++ b/tests/models/test_singletable_minimax.py
@@ -150,9 +150,7 @@ relationship is Husband, fnlwgt is 145441, educational-num is 9, education is HS
 income is <=50K, gender is Male, education is Assoc-acdm, native-country is ?, educational-num is 12, hours-per-week is 7, occupation is Prof-specialty, capital-gain is 0, capital-loss is 0, fnlwgt is 154164, race is White, workclass is Private, age is 66, relationship is Not-in-family, marital-status is Never-married
 """
 
-    def test_extract_samples(
-        self, minimax_model: SingleTableMiniMaxModel, raw_data: pd.DataFrame
-    ):
+    def test_extract_samples(self, minimax_model: SingleTableMiniMaxModel, raw_data: pd.DataFrame):
         minimax_model.fit(raw_data)
         features = minimax_model.extract_samples_from_response(self.minimax_response)
         assert isinstance(features, list)

--- a/tests/models/test_singletable_minimax.py
+++ b/tests/models/test_singletable_minimax.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from sdgx.data_loader import DataLoader
+from sdgx.data_models.metadata import Metadata
+from sdgx.exceptions import InitializationError
+from sdgx.models.LLM.single_table.minimax import MINIMAX_MODELS, SingleTableMiniMaxModel
+
+
+@pytest.fixture
+def minimax_model():
+    yield SingleTableMiniMaxModel()
+
+
+@pytest.fixture
+def raw_data(demo_single_table_path):
+    yield pd.read_csv(demo_single_table_path).head(100)
+
+
+# --- Unit Tests ---
+
+
+class TestMiniMaxModelDefaults:
+    """Test default configuration of SingleTableMiniMaxModel."""
+
+    def test_default_base_url(self, minimax_model: SingleTableMiniMaxModel):
+        assert minimax_model.openai_API_url == "https://api.minimax.io/v1"
+
+    def test_default_model(self, minimax_model: SingleTableMiniMaxModel):
+        assert minimax_model.gpt_model == "MiniMax-M2.7"
+
+    def test_default_temperature(self, minimax_model: SingleTableMiniMaxModel):
+        assert minimax_model.temperature == 1.0
+
+    def test_default_max_tokens(self, minimax_model: SingleTableMiniMaxModel):
+        assert minimax_model.max_tokens == 4000
+
+    def test_default_timeout(self, minimax_model: SingleTableMiniMaxModel):
+        assert minimax_model.timeout == 90
+
+    def test_supported_models(self):
+        assert "MiniMax-M2.7" in MINIMAX_MODELS
+        assert "MiniMax-M2.7-highspeed" in MINIMAX_MODELS
+
+
+class TestMiniMaxModelSettings:
+    """Test configuration and settings."""
+
+    def test_set_minimax_settings(self, minimax_model: SingleTableMiniMaxModel):
+        api_key = "test-minimax-key"
+        api_url = "https://custom.minimax.io/v1"
+        minimax_model.set_minimax_settings(API_url=api_url, API_key=api_key)
+        client = minimax_model.openai_client()
+        assert client.api_key == api_key
+        assert str(client.base_url).rstrip("/") == api_url
+
+    def test_env_minimax_api_key(self, minimax_model: SingleTableMiniMaxModel):
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "env-test-key"}):
+            model = SingleTableMiniMaxModel()
+            assert model.openai_API_key == "env-test-key"
+
+    def test_env_minimax_api_url(self, minimax_model: SingleTableMiniMaxModel):
+        with patch.dict(os.environ, {"MINIMAX_API_URL": "https://custom.url/v1"}):
+            model = SingleTableMiniMaxModel()
+            assert model.openai_API_url == "https://custom.url/v1"
+
+    def test_missing_api_key_raises_error(self, minimax_model: SingleTableMiniMaxModel):
+        minimax_model.openai_API_key = ""
+        with pytest.raises(InitializationError, match="MiniMax API key not found"):
+            minimax_model._check_openAI_setting()
+
+    def test_missing_api_url_raises_error(self, minimax_model: SingleTableMiniMaxModel):
+        minimax_model.openai_API_url = ""
+        with pytest.raises(InitializationError, match="MiniMax API URL not found"):
+            minimax_model._check_openAI_setting()
+
+    def test_valid_settings_pass_check(self, minimax_model: SingleTableMiniMaxModel):
+        minimax_model.openai_API_key = "valid-key"
+        minimax_model.openai_API_url = "https://api.minimax.io/v1"
+        minimax_model._check_openAI_setting()  # Should not raise
+
+
+class TestMiniMaxTemperatureClamping:
+    """Test temperature clamping behavior."""
+
+    def test_temperature_zero_clamped(self):
+        model = SingleTableMiniMaxModel(temperature=0)
+        assert model.temperature == 0.01
+
+    def test_temperature_negative_clamped(self):
+        model = SingleTableMiniMaxModel(temperature=-0.5)
+        assert model.temperature == 0.01
+
+    def test_temperature_above_one_clamped(self):
+        model = SingleTableMiniMaxModel(temperature=1.5)
+        assert model.temperature == 1.0
+
+    def test_temperature_valid_not_changed(self):
+        model = SingleTableMiniMaxModel(temperature=0.7)
+        assert model.temperature == 0.7
+
+    def test_temperature_one_valid(self):
+        model = SingleTableMiniMaxModel(temperature=1.0)
+        assert model.temperature == 1.0
+
+    def test_temperature_small_positive_valid(self):
+        model = SingleTableMiniMaxModel(temperature=0.01)
+        assert model.temperature == 0.01
+
+
+class TestMiniMaxModelFit:
+    """Test model fitting with data and metadata."""
+
+    def test_fit_with_raw_data(
+        self, minimax_model: SingleTableMiniMaxModel, raw_data: pd.DataFrame
+    ):
+        minimax_model.fit(raw_data)
+        assert minimax_model.use_raw_data is True
+        assert minimax_model.use_metadata is False
+        assert len(minimax_model.columns) == len(raw_data.columns)
+
+    def test_fit_with_metadata(
+        self,
+        minimax_model: SingleTableMiniMaxModel,
+        demo_single_table_metadata: Metadata,
+    ):
+        minimax_model.fit(demo_single_table_metadata)
+        assert minimax_model.use_metadata is True
+        assert len(minimax_model.columns) > 0
+
+    def test_fit_with_dataloader(
+        self,
+        minimax_model: SingleTableMiniMaxModel,
+        demo_single_table_data_loader: DataLoader,
+    ):
+        minimax_model.fit(demo_single_table_data_loader)
+        assert len(minimax_model.columns) > 0
+
+
+class TestMiniMaxModelExtraction:
+    """Test response extraction (inherits from GPT model)."""
+
+    minimax_response = """
+relationship is Husband, fnlwgt is 145441, educational-num is 9, education is HS-grad, occupation is Exec-managerial, gender is Male, race is White, workclass is Private, capital-gain is 0, native-country is United-States, marital-status is Married-civ-spouse, income is >50K, age is 40, capital-loss is 1485, hours-per-week is 40
+income is <=50K, gender is Male, education is Assoc-acdm, native-country is ?, educational-num is 12, hours-per-week is 7, occupation is Prof-specialty, capital-gain is 0, capital-loss is 0, fnlwgt is 154164, race is White, workclass is Private, age is 66, relationship is Not-in-family, marital-status is Never-married
+"""
+
+    def test_extract_samples(
+        self, minimax_model: SingleTableMiniMaxModel, raw_data: pd.DataFrame
+    ):
+        minimax_model.fit(raw_data)
+        features = minimax_model.extract_samples_from_response(self.minimax_response)
+        assert isinstance(features, list)
+        assert len(features) == 2
+        assert len(features[0]) == len(minimax_model.columns)
+
+
+class TestMiniMaxModelInheritance:
+    """Test that MiniMaxModel properly inherits from GPTModel."""
+
+    def test_inherits_from_gpt_model(self):
+        from sdgx.models.LLM.single_table.gpt import SingleTableGPTModel
+
+        assert issubclass(SingleTableMiniMaxModel, SingleTableGPTModel)
+
+    def test_client_creation(self, minimax_model: SingleTableMiniMaxModel):
+        minimax_model.openai_API_key = "test-key"
+        client = minimax_model.openai_client()
+        assert client.api_key == "test-key"
+        assert "minimax" in str(client.base_url)
+
+
+# --- Integration Tests (require MINIMAX_API_KEY) ---
+
+
+MINIMAX_API_KEY = os.getenv("MINIMAX_API_KEY")
+
+
+@pytest.mark.skipif(not MINIMAX_API_KEY, reason="MINIMAX_API_KEY not set")
+class TestMiniMaxIntegration:
+    """Integration tests that call the real MiniMax API."""
+
+    def test_ask_minimax_basic(self, demo_single_table_metadata: Metadata):
+        model = SingleTableMiniMaxModel()
+        model.fit(demo_single_table_metadata)
+        response = model.ask_gpt('Say "test passed" in exactly two words.', model="MiniMax-M2.7")
+        assert response is not None
+        assert len(response) > 0
+
+    def test_ask_minimax_highspeed(self, demo_single_table_metadata: Metadata):
+        model = SingleTableMiniMaxModel()
+        model.fit(demo_single_table_metadata)
+        response = model.ask_gpt(
+            'Say "hello world" in exactly two words.', model="MiniMax-M2.7-highspeed"
+        )
+        assert response is not None
+        assert len(response) > 0
+
+    def test_sample_with_metadata(self, demo_single_table_metadata: Metadata):
+        model = SingleTableMiniMaxModel()
+        model.query_batch = 5
+        model.fit(demo_single_table_metadata)
+        result = model.sample(5)
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) > 0


### PR DESCRIPTION
## Summary

Add [MiniMax](https://platform.minimax.io) as an alternative LLM provider for synthetic tabular data generation, complementing the existing OpenAI GPT support.

### Changes

- **New `SingleTableMiniMaxModel`**: Inherits from `SingleTableGPTModel`, uses MiniMax's OpenAI-compatible API
- **Supported models**: `MiniMax-M2.7` (default) and `MiniMax-M2.7-highspeed`
- **Environment variables**: `MINIMAX_API_KEY` and `MINIMAX_API_URL` (defaults to `https://api.minimax.io/v1`)
- **Temperature clamping**: Automatically clamps temperature to MiniMax's valid range (0.0, 1.0]
- **24 unit tests + 3 integration tests**
- **README update**: Added MiniMax quick start section

### Usage

```python
import os
os.environ["MINIMAX_API_KEY"] = "your-key"

from sdgx.models.LLM.single_table.minimax import SingleTableMiniMaxModel

model = SingleTableMiniMaxModel()
model.fit(raw_data)
synthetic_data = model.sample(100)
```

### Files Changed (4 files, ~360 additions)

| File | Description |
|------|-------------|
| `sdgx/models/LLM/single_table/minimax.py` | MiniMax model implementation |
| `sdgx/models/LLM/single_table/__init__.py` | Export new model |
| `tests/models/test_singletable_minimax.py` | 24 unit + 3 integration tests |
| `README.md` | MiniMax documentation section |

### API Reference

- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api
- Pricing: https://platform.minimax.io/docs/guides/pricing-paygo

### Test Plan

- [x] Unit tests pass (24/24)
- [x] Integration tests pass with real MiniMax API (3/3)
- [x] Existing GPT model tests unaffected
- [x] Temperature clamping works correctly
- [x] Environment variable loading works
